### PR TITLE
V10

### DIFF
--- a/module/actors/actor-sheet.js
+++ b/module/actors/actor-sheet.js
@@ -30,7 +30,7 @@ export class CoCActorSheet extends CoCBaseSheet {
     getData(options = {}) {
         const data = super.getData(options);
         if (COC.debug) console.log("COC | ActorSheet getData", data);
-        
+
         // The Actor's data
         const actorData = this.actor.data.toObject(false);
 

--- a/module/actors/actor-sheet.js
+++ b/module/actors/actor-sheet.js
@@ -32,7 +32,7 @@ export class CoCActorSheet extends CoCBaseSheet {
         if (COC.debug) console.log("COC | ActorSheet getData", data);
 
         // The Actor's data
-        const actorData = this.actor.data.toObject(false);
+        const actorData = this.actor.toObject(false);
 
         // Owned Items
         data.profile = actorData.items.find(item => item.type === "profile");
@@ -50,18 +50,18 @@ export class CoCActorSheet extends CoCBaseSheet {
             id: "standalone-capacities",
             label: "Capacités Hors-Voies",
             items: Object.values(actorData.items).filter(item => {
-                if (item.type === "capacity" && item.data.path.key === "") {
+                if (item.type === "capacity" && item.system.path.key === "") {
                     return true;
                 }
             }).sort((a, b) => (a.name > b.name) ? 1 : -1)
         });
         for (const path of paths) {
             data.capacities.collections.push({
-                id: (path.data.key) ? path.data.key : path.name.slugify({ strict: true }),
+                id: (path.system.key) ? path.system.key : path.name.slugify({ strict: true }),
                 label: path.name,
                 items: Object.values(actorData.items).filter(item => {
-                    if (item.type === "capacity" && item.data.path._id === path._id) return true;
-                }).sort((a, b) => (a.data.rank > b.data.rank) ? 1 : -1)
+                    if (item.type === "capacity" && item.system.path._id === path._id) return true;
+                }).sort((a, b) => (a.system.rank > b.system.rank) ? 1 : -1)
             });
         }
 
@@ -78,7 +78,7 @@ export class CoCActorSheet extends CoCBaseSheet {
 
         // Combat and Inventory
         data.combat = {
-            count: data.items.filter(i => i.data.worn).length,
+            count: data.items.filter(i => i.system.worn).length,
             categories: []
         };
         data.inventory = {
@@ -89,31 +89,31 @@ export class CoCActorSheet extends CoCBaseSheet {
             data.combat.categories.push({
                 id: category,
                 label: game.coc.config.itemCategories[category],
-                items: Object.values(data.items).filter(item => item.type === "item" && item.data.subtype === category && item.data.worn && (item.data.properties.weapon || item.data.properties.protection)).sort((a, b) => (a.name > b.name) ? 1 : -1)
+                items: Object.values(data.items).filter(item => item.type === "item" && item.system.subtype === category && item.system.worn && (item.system.properties.weapon || item.system.properties.protection)).sort((a, b) => (a.name > b.name) ? 1 : -1)
             });
             data.inventory.categories.push({
                 id: category,
                 label: "COC.category." + category,
-                items: Object.values(data.items).filter(item => item.type === "item" && item.data.subtype === category).sort((a, b) => (a.name > b.name) ? 1 : -1)
+                items: Object.values(data.items).filter(item => item.type === "item" && item.system.subtype === category).sort((a, b) => (a.name > b.name) ? 1 : -1)
             });
         }
 
         data.combat.categories.forEach(category => {
             if (category.items.length > 0) {
                 category.items.forEach(item => {
-                    if (item.data.properties?.weapon) {
+                    if (item.system.properties?.weapon) {
                         // Compute MOD
-                        const itemModStat = item.data.skill.split("@")[1];
-                        const itemModBonus = parseInt(item.data.skillBonus);
+                        const itemModStat = item.system.skill.split("@")[1];
+                        const itemModBonus = parseInt(item.system.skillBonus);
 
-                        item.data.mod = this.actor.computeWeaponMod(itemModStat, itemModBonus);
+                        item.system.mod = this.actor.computeWeaponMod(itemModStat, itemModBonus);
 
                         // Compute DM
-                        const itemDmgBase = item.data.dmgBase;
-                        const itemDmgStat = item.data.dmgStat.split("@")[1];
-                        const itemDmgBonus = parseInt(item.data.dmgBonus);
+                        const itemDmgBase = item.system.dmgBase;
+                        const itemDmgStat = item.system.dmgStat.split("@")[1];
+                        const itemDmgBonus = parseInt(item.system.dmgBonus);
 
-                        item.data.dmg = this.actor.computeDm(itemDmgBase, itemDmgStat, itemDmgBonus)
+                        item.system.dmg = this.actor.computeDm(itemDmgBase, itemDmgStat, itemDmgBonus)
                     }
                 });
             }

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -12,10 +12,10 @@ export class CoCActor extends Actor {
     /*  Constructor                                 */
     /* -------------------------------------------- */
     /* Définition des images par défaut             */
-    /* -------------------------------------------- */   
+    /* -------------------------------------------- */
     constructor(...args) {
         let data = args[0];
-        
+
         if (!data.img && COC.actorIcons[data.type]){
             data.img = COC.actorIcons[data.type];
             if (!data.token) data.token = {};
@@ -40,7 +40,7 @@ export class CoCActor extends Actor {
                 "effects": { "folded": [] }
             };
         }
-    }    
+    }
 
     /* -------------------------------------------- */
     /* Après application des effets                 */
@@ -53,10 +53,10 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
-    _prepareDerivedEncounterData(actorData) { 
+    _prepareDerivedEncounterData(actorData) {
         // Stats
         this.computeNpcMods(actorData);
 
@@ -78,13 +78,13 @@ export class CoCActor extends Actor {
         // Attaques
         let attacks = actorData.data.attacks;
         for (let attack of Object.values(attacks)) {
-            attack.mod = attack.base + attack.bonus; 
+            attack.mod = attack.base + attack.bonus;
         }
     }
-    
+
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
     _prepareDerivedCharacterData(actorData) {
         if(actorData.type === "npc") this.computeNpcMods(actorData);
@@ -97,9 +97,9 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} items 
-     * @returns 
+     *
+     * @param {*} items
+     * @returns
      */
     getProfile(items) {
         let profile = items.find(i => i.type === "profile")
@@ -108,9 +108,9 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} items 
-     * @returns 
+     *
+     * @param {*} items
+     * @returns
      */
     getProtection(items) {
         const protections = items.filter(i => i.type === "item" && i.data.data.worn && i.data.data.def).map(i => i.data.data.def);
@@ -120,21 +120,21 @@ export class CoCActor extends Actor {
     /**
      * @name
      * @description Calcule le malus due à la Défense. Le bonus d'une armure diminue le malus d'autant
-     
-     * @param {*} items 
+
+     * @param {*} items
      * @returns {int} retourne le malus 0 ou un nombre négatif
      */
     getMalusFromProtection(items) {
         let malus = 0;
-        let protections = items.filter(i => i.data.type === "item" && i.data.data.subtype === "armor" && i.data.data.worn && i.data.data.def).map(i => (-1 * i.data.data.defBase) + i.data.data.defBonus);     
+        let protections = items.filter(i => i.data.type === "item" && i.data.data.subtype === "armor" && i.data.data.worn && i.data.data.def).map(i => (-1 * i.data.data.defBase) + i.data.data.defBonus);
         if (protections.length > 0) malus = protections.reduce((acc, curr) => acc + curr, 0);
         return malus;
     }
 
     /**
-     * 
-     * @param {*} items 
-     * @returns 
+     *
+     * @param {*} items
+     * @returns
      */
     getResistance(items) {
         const resistances = items.filter(i => i.type === "item" && i.data.data.worn && i.data.data.dr).map(i => i.data.data.dr);
@@ -142,9 +142,9 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} items 
-     * @returns 
+     *
+     * @param {*} items
+     * @returns
      */
     getCurrentXP(items) {
         const capacities = items.filter(i => i.type === "capacity");
@@ -152,8 +152,8 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
     computeMods(actorData) {
         let stats = actorData.data.stats;
@@ -164,8 +164,8 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
     computeNpcMods(actorData) {
         let stats = actorData.data.stats;
@@ -175,8 +175,8 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
     computeAttributes(actorData) {
 
@@ -214,8 +214,8 @@ export class CoCActor extends Actor {
     }
 
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
     computeAttacks(actorData) {
 
@@ -245,19 +245,19 @@ export class CoCActor extends Actor {
         magic.base = (magicMod) ? magicMod + atmBonus : atmBonus;
 
         for (let attack of Object.values(attacks)) {
-            attack.mod = attack.base + attack.bonus + attack.malus; 
+            attack.mod = attack.base + attack.bonus + attack.malus;
         }
 
     }
 
     /**
-     * 
-     * @param {*} actorData 
+     *
+     * @param {*} actorData
      */
     computeDef(actorData) {
         let stats = actorData.data.stats;
         let attributes = actorData.data.attributes;
-        
+
         // Calcule DEF et RD
         const protection = this.getProtection(actorData.items);
         const dr = this.getResistance(actorData.items);
@@ -273,7 +273,7 @@ export class CoCActor extends Actor {
     /**
      * @name computeXP
      * @description calcule les XPs dépensés dans les capacités
-     * @param {*} actorData 
+     * @param {*} actorData
      */
     computeXP(actorData) {
         let items = actorData.items;
@@ -306,16 +306,16 @@ export class CoCActor extends Actor {
     /**
      * @name computeWeaponMod
      * @description calcule le modificateur final pour une arme
-     *  Total = Mod lié à la caractéristique + Mod lié au bonus 
+     *  Total = Mod lié à la caractéristique + Mod lié au bonus
      * @param {int} itemModStat le modificateur issue de la caractéristique
      * @param {int} itemModBonus le modificateur issue du bonus
 
      * @returns {int} retourne mod
-     */       
+     */
      computeWeaponMod(itemModStat, itemModBonus) {
         let total = 0;
 
-        const fromStat = eval("this.data.data." + itemModStat);        
+        const fromStat = eval("this.data.data." + itemModStat);
         total = fromStat + itemModBonus;
 
         return total;
@@ -330,10 +330,10 @@ export class CoCActor extends Actor {
      * @param {int} itemDmgBonus le bonus aux dégâts
 
      * @returns {string} retourne la chaine de caractères utilisée pour le lancer de dés
-     */      
+     */
     computeDm(itemDmgBase, itemDmgStat, itemDmgBonus) {
         let total = itemDmgBase;
-        
+
         const fromStat = eval("this.data.data." + itemDmgStat);
         const fromBonus = (fromStat) ? parseInt(fromStat) + itemDmgBonus : itemDmgBonus;
         if (fromBonus < 0) total = itemDmgBase + " - " + parseInt(-fromBonus);
@@ -354,14 +354,14 @@ export class CoCActor extends Actor {
 
     /**
     * @name syncItemActiveEffects
-    * @param {*} item 
+    * @param {*} item
     * @description synchronise l'état des effets qui appartiennent à un item équipable avec l'état "équipé" de cet item
     * @returns {Promise}
     */
      syncItemActiveEffects(item){
         // Récupération des effets qui proviennent de l'item
         let effectsData = this.effects.filter(effect=>effect.data.origin.endsWith(item.id))?.map(effect=> duplicate(effect.data));
-        if (effectsData.length > 0){        
+        if (effectsData.length > 0){
             effectsData.forEach(effect=>effect.disabled = !item.data.data.worn);
 
             this.updateEmbeddedDocuments("ActiveEffect", effectsData);
@@ -377,16 +377,16 @@ export class CoCActor extends Actor {
         const { bonus = 0, malus = 0, dmgBonus = 0, dmgOnly = false } = options;
 
         return Macros.rollItemMacro(item.id, item.name, item.type, bonus, malus, dmgBonus, dmgOnly);
-     }    
+     }
 
     /**
-     * 
-     * @param {*} item 
-     * @param {*} bypassChecks 
-     * @returns 
+     *
+     * @param {*} item
+     * @param {*} bypassChecks
+     * @returns
      */
      toggleEquipItem(item, bypassChecks) {
-        if (!this.canEquipItem(item, bypassChecks)) return;        
+        if (!this.canEquipItem(item, bypassChecks)) return;
 
         const equipable = item.data.data.properties.equipable;
         if(equipable){
@@ -403,8 +403,8 @@ export class CoCActor extends Actor {
     /**
      * Check if an item can be equiped
      * @param item
-     * @param bypassChecks      
-     */        
+     * @param bypassChecks
+     */
      canEquipItem(item, bypassChecks) {
         if (!this.items.some(it=>it.id === item.id)){
             ui.notifications.warn(game.i18n.format('COC.notification.MacroItemMissing', {item:item.name}));
@@ -415,7 +415,7 @@ export class CoCActor extends Actor {
             ui.notifications.warn(game.i18n.format("COC.notification.ItemNotEquipable", {itemName:item.name}));
             return;
         }
-      
+
         if (!this._hasEnoughFreeHands(item, bypassChecks)){
             ui.notifications.warn(game.i18n.localize("COC.notification.NotEnoughFreeHands"));
             return false;
@@ -424,24 +424,24 @@ export class CoCActor extends Actor {
             ui.notifications.warn(game.i18n.localize("COC.notification.ArmorSlotNotAvailable"));
             return false;
         }
-        
+
         return true;
     }
 
    /**
      * Check if actor has enough free hands to equip this item
      * @param event
-     * @param bypassChecks     
+     * @param bypassChecks
      * @private
-     */    
+     */
     _hasEnoughFreeHands(item, bypassChecks){
         // Si le contrôle de mains libres n'est pas demandé, on renvoi Vrai
         let checkFreehands = game.settings.get("coc", "checkFreeHandsBeforeEquip");
         if (!checkFreehands || checkFreehands === "none") return true;
 
         // Si le contrôle est ignoré ponctuellement avec la touche MAJ, on renvoi Vrai
-        if (bypassChecks && (checkFreehands === "all" || (checkFreehands === "gm" && game.user.isGM))) return true;      
-        
+        if (bypassChecks && (checkFreehands === "all" || (checkFreehands === "gm" && game.user.isGM))) return true;
+
         // Si l'objet est équipé, on tente de le déséquiper donc on ne fait pas de contrôle et on renvoi Vrai
         if (item.data.data.worn) return true;
 
@@ -454,17 +454,17 @@ export class CoCActor extends Actor {
         // Calcul du nombre de mains déjà utilisées
         let itemsInHands = this.items.filter(item=>item.data.data.worn && item.data.data.slot === "hand");
         let usedHands = 0;
-        itemsInHands.forEach(item=>usedHands += item.data.data.properties["2H"] ? 2 : 1);                
+        itemsInHands.forEach(item=>usedHands += item.data.data.properties["2H"] ? 2 : 1);
 
-        return usedHands + neededHands <= 2;        
+        return usedHands + neededHands <= 2;
     }
 
     /**
      * Check if armor slot is available to equip this item
      * @param event
-     * @param bypassChecks          
+     * @param bypassChecks
      * @private
-     */        
+     */
     _isArmorSlotAvailable(item, bypassChecks){
         // Si le contrôle de disponibilité de l'emplacement d'armure n'est pas demandé, on renvoi Vrai
         let checkArmorSlotAvailability = game.settings.get("coc", "checkArmorSlotAvailability");
@@ -472,12 +472,12 @@ export class CoCActor extends Actor {
 
         // Si le contrôle est ignoré ponctuellement avec la touche MAJ, on renvoi Vrai
         if (bypassChecks && (checkArmorSlotAvailability === "all" || (checkArmorSlotAvailability === "gm" && game.user.isGM))) return true;
-        
+
         const itemData = item.data.data;
 
         // Si l'objet est équipé, on tente de le déséquiper donc on ne fait pas de contrôle et on renvoi Vrai
         if (itemData.worn) return true;
-        
+
         // Si l'objet n'est pas une protection, on renvoi Vrai
         if (!itemData.properties.protection) return true;
 
@@ -487,15 +487,15 @@ export class CoCActor extends Actor {
 
             return slotItemData.properties?.protection && slotItemData.properties.equipable && slotItemData.worn && slotItemData.slot === itemData.slot;
         });
-        
+
         // Renvoie vrai si le le slot est libre, sinon renvoi faux
-        return !equipedItem;    
-    }   
+        return !equipedItem;
+    }
 
     /**
      * Consume one item
-     * @param {*} item 
-     * @returns 
+     * @param {*} item
+     * @returns
      */
     consumeItem(item) {
         const consumable = item.data.data.properties.consumable;
@@ -507,16 +507,16 @@ export class CoCActor extends Actor {
             AudioHelper.play({ src: "/systems/coc/sounds/gulp.mp3", volume: 0.8, autoplay: true, loop: false }, false);
             return item.update(itemData).then(item => item.applyEffects(this));
         }
-    }    
+    }
 
     /**
      * @name computeBaseFP
      * @description Calcule le nombre de points de chance de base
      * @public
-     * 
+     *
      * @param {Int} charismeMod Modificateur de charisme
      * @param {CofItem} profile Item de type profile
-     * 
+     *
      */
      computeBaseFP(charismeMod, profile) {
          if (game.settings.get("coc", "settingCyberpunk")){
@@ -525,6 +525,6 @@ export class CoCActor extends Actor {
          else {
             const fpBonusFromProfile = (profile && profile.data.bonuses.fp) ? profile.data.bonuses.fp : 0;
             return 2 + charismeMod + fpBonusFromProfile;
-         }        
+         }
     }
 }

--- a/module/actors/actor.js
+++ b/module/actors/actor.js
@@ -31,9 +31,9 @@ export class CoCActor extends Actor {
     /* -------------------------------------------- */
     /** @override */
     prepareBaseData() {
-        let actorData = this.data;
-        if (!actorData.data.settings) {
-            actorData.data.settings = {
+        let actorData = this;
+        if (!actorData.system.settings) {
+            actorData.system.settings = {
                 "combat": { "folded": [] },
                 "inventory": { "folded": [] },
                 "capacities": { "folded": [] },
@@ -47,7 +47,7 @@ export class CoCActor extends Actor {
     /* -------------------------------------------- */
     /** @override */
     prepareDerivedData() {
-        let actorData = this.data;
+        let actorData = this;
         if (actorData.type === "encounter") this._prepareDerivedEncounterData(actorData);
         else this._prepareDerivedCharacterData(actorData);
     }
@@ -61,7 +61,7 @@ export class CoCActor extends Actor {
         this.computeNpcMods(actorData);
 
         // Attributs
-        let attributes = actorData.data.attributes;
+        let attributes = actorData.system.attributes;
 
         // Initiative
         attributes.init.value = attributes.init.base + attributes.init.bonus;
@@ -76,7 +76,7 @@ export class CoCActor extends Actor {
         attributes.dr.value = attributes.dr.base.value + attributes.dr.bonus.value;
 
         // Attaques
-        let attacks = actorData.data.attacks;
+        let attacks = actorData.system.attacks;
         for (let attack of Object.values(attacks)) {
             attack.mod = attack.base + attack.bonus;
         }
@@ -103,7 +103,7 @@ export class CoCActor extends Actor {
      */
     getProfile(items) {
         let profile = items.find(i => i.type === "profile")
-        if(profile) return profile.data;
+        if(profile) return profile;
         else return null;
     }
 
@@ -113,7 +113,7 @@ export class CoCActor extends Actor {
      * @returns
      */
     getProtection(items) {
-        const protections = items.filter(i => i.type === "item" && i.data.data.worn && i.data.data.def).map(i => i.data.data.def);
+        const protections = items.filter(i => i.type === "item" && i.system.worn && i.system.def).map(i => i.system.def);
         return protections.reduce((acc, curr) => acc + curr, 0);
     }
 
@@ -126,7 +126,7 @@ export class CoCActor extends Actor {
      */
     getMalusFromProtection(items) {
         let malus = 0;
-        let protections = items.filter(i => i.data.type === "item" && i.data.data.subtype === "armor" && i.data.data.worn && i.data.data.def).map(i => (-1 * i.data.data.defBase) + i.data.data.defBonus);
+        let protections = items.filter(i => i.type === "item" && i.system.subtype === "armor" && i.system.worn && i.system.def).map(i => (-1 * i.system.defBase) + i.system.defBonus);
         if (protections.length > 0) malus = protections.reduce((acc, curr) => acc + curr, 0);
         return malus;
     }
@@ -137,7 +137,7 @@ export class CoCActor extends Actor {
      * @returns
      */
     getResistance(items) {
-        const resistances = items.filter(i => i.type === "item" && i.data.data.worn && i.data.data.dr).map(i => i.data.data.dr);
+        const resistances = items.filter(i => i.type === "item" && i.system.worn && i.system.dr).map(i => i.system.dr);
         return resistances.reduce((acc, curr) => acc + curr, 0);
     }
 
@@ -148,7 +148,7 @@ export class CoCActor extends Actor {
      */
     getCurrentXP(items) {
         const capacities = items.filter(i => i.type === "capacity");
-        return capacities.map(cap => (cap.data.data.rank > 2) ? 2 : 1).reduce((acc, curr) => acc + curr, 0);
+        return capacities.map(cap => (cap.system.rank > 2) ? 2 : 1).reduce((acc, curr) => acc + curr, 0);
     }
 
     /**
@@ -156,7 +156,7 @@ export class CoCActor extends Actor {
      * @param {*} actorData
      */
     computeMods(actorData) {
-        let stats = actorData.data.stats;
+        let stats = actorData.system.stats;
         for(const stat of Object.values(stats)){
             stat.value = stat.base + stat.bonus;
             stat.mod = Stats.getModFromStatValue(stat.value);
@@ -168,7 +168,7 @@ export class CoCActor extends Actor {
      * @param {*} actorData
      */
     computeNpcMods(actorData) {
-        let stats = actorData.data.stats;
+        let stats = actorData.system.stats;
         for(const stat of Object.values(stats)){
             stat.value = Stats.getStatValueFromMod(stat.mod);
         }
@@ -180,10 +180,10 @@ export class CoCActor extends Actor {
      */
     computeAttributes(actorData) {
 
-        let stats = actorData.data.stats;
-        let attributes = actorData.data.attributes;
+        let stats = actorData.system.stats;
+        let attributes = actorData.system.attributes;
         let items = actorData.items;
-        let lvl = actorData.data.level.value;
+        let lvl = actorData.system.level.value;
 
         const profile = this.getProfile(items);
         const protection = this.getProtection(items);
@@ -210,7 +210,7 @@ export class CoCActor extends Actor {
         attributes.mp.base = lvl + stats.cha.mod;
         attributes.mp.max = attributes.mp.base + attributes.mp.bonus;
 
-        attributes.hd.value = (profile && profile.data.dv) ? profile.data.dv : attributes.hd.value;
+        attributes.hd.value = (profile && profile.system.dv) ? profile.system.dv : attributes.hd.value;
     }
 
     /**
@@ -219,8 +219,8 @@ export class CoCActor extends Actor {
      */
     computeAttacks(actorData) {
 
-        let stats = actorData.data.stats;
-        let attacks = actorData.data.attacks;
+        let stats = actorData.system.stats;
+        let attacks = actorData.system.attacks;
 
         let melee = attacks.melee;
         let ranged = attacks.ranged;
@@ -232,13 +232,13 @@ export class CoCActor extends Actor {
         const profile = this.getProfile(actorData.items);
 
         // STATS RELATED TO PROFILE
-        attacks.magic.stat = (profile && profile.data.spellcasting) ? profile.data.spellcasting : attacks.magic.stat;
+        attacks.magic.stat = (profile && profile.system.spellcasting) ? profile.system.spellcasting : attacks.magic.stat;
 
         let magicMod = eval(attacks.magic.stat.split("@")[1]);
 
-        const atcBonus = (profile) ? profile.data.bonuses.atc : 0;
-        const atdBonus = (profile) ? profile.data.bonuses.atd : 0;
-        const atmBonus = (profile) ? profile.data.bonuses.atm : 0;
+        const atcBonus = (profile) ? profile.system.bonuses.atc : 0;
+        const atdBonus = (profile) ? profile.system.bonuses.atd : 0;
+        const atmBonus = (profile) ? profile.system.bonuses.atm : 0;
 
         melee.base = (strMod) ? strMod + atcBonus : atcBonus;
         ranged.base = (dexMod) ? dexMod + atdBonus : atdBonus;
@@ -255,8 +255,8 @@ export class CoCActor extends Actor {
      * @param {*} actorData
      */
     computeDef(actorData) {
-        let stats = actorData.data.stats;
-        let attributes = actorData.data.attributes;
+        let stats = actorData.system.stats;
+        let attributes = actorData.system.attributes;
 
         // Calcule DEF et RD
         const protection = this.getProtection(actorData.items);
@@ -277,17 +277,17 @@ export class CoCActor extends Actor {
      */
     computeXP(actorData) {
         let items = actorData.items;
-        let lvl = actorData.data.level.value;
-        const alert = actorData.data.alert;
+        let lvl = actorData.system.level.value;
+        const alert = actorData.system.alert;
 
         const profile = this.getProfile(actorData.items);
 
         let currxp = this.getCurrentXP(items);
-        const maxxp = (profile && profile.data.bonuses.xp) ? 2 * lvl + profile.data.bonuses.xp : 2 * lvl;
+        const maxxp = (profile && profile.system.bonuses.xp) ? 2 * lvl + profile.system.bonuses.xp : 2 * lvl;
 
         // UPDATE XP
-        actorData.data.xp.max = maxxp;
-        actorData.data.xp.value = maxxp - currxp;
+        actorData.system.xp.max = maxxp;
+        actorData.system.xp.value = maxxp - currxp;
 
         if (maxxp - currxp < 0) {
             const diff = currxp - maxxp;
@@ -315,7 +315,7 @@ export class CoCActor extends Actor {
      computeWeaponMod(itemModStat, itemModBonus) {
         let total = 0;
 
-        const fromStat = eval("this.data.data." + itemModStat);
+        const fromStat = eval("this.system." + itemModStat);
         total = fromStat + itemModBonus;
 
         return total;
@@ -334,7 +334,7 @@ export class CoCActor extends Actor {
     computeDm(itemDmgBase, itemDmgStat, itemDmgBonus) {
         let total = itemDmgBase;
 
-        const fromStat = eval("this.data.data." + itemDmgStat);
+        const fromStat = eval("this.system." + itemDmgStat);
         const fromBonus = (fromStat) ? parseInt(fromStat) + itemDmgBonus : itemDmgBonus;
         if (fromBonus < 0) total = itemDmgBase + " - " + parseInt(-fromBonus);
         if (fromBonus > 0) total = itemDmgBase + " + " + fromBonus;
@@ -360,9 +360,9 @@ export class CoCActor extends Actor {
     */
      syncItemActiveEffects(item){
         // Récupération des effets qui proviennent de l'item
-        let effectsData = this.effects.filter(effect=>effect.data.origin.endsWith(item.id))?.map(effect=> duplicate(effect.data));
+        let effectsData = this.effects.filter(effect=>effect.origin.endsWith(item.id))?.map(effect=> duplicate(effect));
         if (effectsData.length > 0){
-            effectsData.forEach(effect=>effect.disabled = !item.data.data.worn);
+            effectsData.forEach(effect=>effect.disabled = !item.system.worn);
 
             this.updateEmbeddedDocuments("ActiveEffect", effectsData);
         }
@@ -388,10 +388,10 @@ export class CoCActor extends Actor {
      toggleEquipItem(item, bypassChecks) {
         if (!this.canEquipItem(item, bypassChecks)) return;
 
-        const equipable = item.data.data.properties.equipable;
+        const equipable = item.system.properties.equipable;
         if(equipable){
-            let itemData = duplicate(item.data);
-            itemData.data.worn = !itemData.data.worn;
+            let itemData = duplicate(item);
+            itemData.system.worn = !itemData.system.worn;
 
             return item.update(itemData).then((item)=>{
                 AudioHelper.play({ src: "/systems/coc/sounds/sword.mp3", volume: 0.8, autoplay: true, loop: false }, false);
@@ -410,7 +410,7 @@ export class CoCActor extends Actor {
             ui.notifications.warn(game.i18n.format('COC.notification.MacroItemMissing', {item:item.name}));
             return false;
         }
-        let itemData = item.data.data;
+        let itemData = item.system;
         if (!itemData?.properties.equipment || !itemData?.properties.equipable){
             ui.notifications.warn(game.i18n.format("COC.notification.ItemNotEquipable", {itemName:item.name}));
             return;
@@ -443,18 +443,18 @@ export class CoCActor extends Actor {
         if (bypassChecks && (checkFreehands === "all" || (checkFreehands === "gm" && game.user.isGM))) return true;
 
         // Si l'objet est équipé, on tente de le déséquiper donc on ne fait pas de contrôle et on renvoi Vrai
-        if (item.data.data.worn) return true;
+        if (item.system.worn) return true;
 
         // Si l'objet n'est pas tenu en main, on renvoi Vrai
-        if (item.data.data.slot !== "hand") return true;
+        if (item.system.slot !== "hand") return true;
 
         // Nombre de mains nécessaire pour l'objet que l'on veux équipper
-        let neededHands = item.data.data.properties["2H"] ? 2 : 1;
+        let neededHands = item.system.properties["2H"] ? 2 : 1;
 
         // Calcul du nombre de mains déjà utilisées
-        let itemsInHands = this.items.filter(item=>item.data.data.worn && item.data.data.slot === "hand");
+        let itemsInHands = this.items.filter(item=>item.system.worn && item.system.slot === "hand");
         let usedHands = 0;
-        itemsInHands.forEach(item=>usedHands += item.data.data.properties["2H"] ? 2 : 1);
+        itemsInHands.forEach(item=>usedHands += item.system.properties["2H"] ? 2 : 1);
 
         return usedHands + neededHands <= 2;
     }
@@ -473,7 +473,7 @@ export class CoCActor extends Actor {
         // Si le contrôle est ignoré ponctuellement avec la touche MAJ, on renvoi Vrai
         if (bypassChecks && (checkArmorSlotAvailability === "all" || (checkArmorSlotAvailability === "gm" && game.user.isGM))) return true;
 
-        const itemData = item.data.data;
+        const itemData = item.system;
 
         // Si l'objet est équipé, on tente de le déséquiper donc on ne fait pas de contrôle et on renvoi Vrai
         if (itemData.worn) return true;
@@ -483,7 +483,7 @@ export class CoCActor extends Actor {
 
         // Recheche d'une item de type protection déjà équipé dans le slot cible
         let equipedItem = this.items.find((slotItem)=>{
-            let slotItemData = slotItem.data.data;
+            let slotItemData = slotItem.system;
 
             return slotItemData.properties?.protection && slotItemData.properties.equipable && slotItemData.worn && slotItemData.slot === itemData.slot;
         });
@@ -498,12 +498,12 @@ export class CoCActor extends Actor {
      * @returns
      */
     consumeItem(item) {
-        const consumable = item.data.data.properties.consumable;
-        const quantity = item.data.data.qty;
+        const consumable = item.system.properties.consumable;
+        const quantity = item.system.qty;
 
         if(consumable && quantity>0){
-            let itemData = duplicate(item.data);
-            itemData.data.qty = (itemData.data.qty > 0) ? itemData.data.qty - 1 : 0;
+            let itemData = duplicate(item);
+            itemData.system.qty = (itemData.system.qty > 0) ? itemData.system.qty - 1 : 0;
             AudioHelper.play({ src: "/systems/coc/sounds/gulp.mp3", volume: 0.8, autoplay: true, loop: false }, false);
             return item.update(itemData).then(item => item.applyEffects(this));
         }
@@ -523,7 +523,7 @@ export class CoCActor extends Actor {
              return 3 + charismeMod;
          }
          else {
-            const fpBonusFromProfile = (profile && profile.data.bonuses.fp) ? profile.data.bonuses.fp : 0;
+            const fpBonusFromProfile = (profile && profile.system.bonuses.fp) ? profile.system.bonuses.fp : 0;
             return 2 + charismeMod + fpBonusFromProfile;
          }
     }

--- a/module/actors/base-sheet.js
+++ b/module/actors/base-sheet.js
@@ -226,7 +226,7 @@ export class CoCBaseSheet extends ActorSheet {
         const item = this.actor.items.get(li.data("itemId"));
 
         this.actor.consumeItem(item);
-    }    
+    }
 
     _onToggleEquip(event) {
         event.preventDefault();
@@ -237,7 +237,7 @@ export class CoCBaseSheet extends ActorSheet {
 
         return this.actor.toggleEquipItem(item, bypassChecks);
     }
-    
+
     /* -------------------------------------------- */
     /* DELETE EVENTS CALLBACKS                      */
     /* -------------------------------------------- */
@@ -292,7 +292,7 @@ export class CoCBaseSheet extends ActorSheet {
 
         const item = await Item.fromDropData(data);
         if (!COC.actorsAllowedItems[this.actor.data.type]?.includes(item.data.type)) return;
-        
+
         const itemData = duplicate(item.data);
         switch (itemData.type) {
             case "path": return await Path.addToActor(this.actor, item);
@@ -307,14 +307,14 @@ export class CoCBaseSheet extends ActorSheet {
 
                 // On force le nouvel Item a ne pas être équipé (notamment lors du transfert d'un inventaire à un autre)
                 if (itemData.data.worn) itemData.data.worn = false;
-                
+
                 // Create the owned item
-                return this.actor.createEmbeddedDocuments("Item", [itemData]).then((item)=>{                    
+                return this.actor.createEmbeddedDocuments("Item", [itemData]).then((item)=>{
                     // Si il n'y as pas d'actor id, il s'agit d'un objet du compendium, on quitte
                     if (!data.actorId) return item;
-                                        
+
                     // Si l'item doit être "move", on le supprime de l'actor précédent
-                    let moveItem = game.settings.get("coc","moveItem");                    
+                    let moveItem = game.settings.get("coc","moveItem");
                     if (moveItem ^ event.shiftKey) {
 
                         if (!data.tokenId){
@@ -326,13 +326,13 @@ export class CoCBaseSheet extends ActorSheet {
                             let oldItem = token?.document.getEmbeddedCollection('Item').get(data.data._id);
                             oldItem?.delete();
                         }
-                    }                     
+                    }
                 });
             }
         }
     }
-      
-      
+
+
     /* -------------------------------------------- */
     /* ROLL EVENTS CALLBACKS                        */
     /* -------------------------------------------- */
@@ -350,7 +350,7 @@ export class CoCBaseSheet extends ActorSheet {
         if (event.shiftKey) {
             switch (rolltype) {
                 // Spend recovery point without getting hit points
-                case "recovery": return CoCRoll.rollRecoveryUse(data.data, this.actor, false)    
+                case "recovery": return CoCRoll.rollRecoveryUse(data.data, this.actor, false)
             }
         }
         switch (rolltype) {
@@ -359,7 +359,7 @@ export class CoCBaseSheet extends ActorSheet {
             case "damage" : return CoCRoll.rollDamage(data.data, this.actor, event);
             case "encounter-weapon" : return CoCRoll.rollEncounterWeapon(data.data, this.actor, event);
             case "encounter-damage" : return CoCRoll.rollEncounterDamage(data.data, this.actor, event);
-            case "spell" : return CoCRoll.rollSpell(data.data, this.actor, event);            
+            case "spell" : return CoCRoll.rollSpell(data.data, this.actor, event);
             case "hp" : return CoCRoll.rollHitPoints(data.data, this.actor, event);
             case "attributes" : return CoCRoll.rollAttributes(data.data, this.actor, event);
             case "recovery": return CoCRoll.rollRecoveryUse(data.data, this.actor, true);
@@ -371,7 +371,7 @@ export class CoCBaseSheet extends ActorSheet {
         const data = super.getData(options);
         const actorData = data.data;
 		data.isGm = game.user.isGM;
-        
+
         // Basic data
         let isOwner = this.actor.isOwner;
 
@@ -386,16 +386,16 @@ export class CoCBaseSheet extends ActorSheet {
         data.isEncounter = this.actor.type === "encounter";
         data.isVehicle =  this.actor.type === 'vehicle';
         data.rollData =  this.actor.getRollData.bind(this.actor);
-        
+
         data.effects = data.actor.effects;
         data.folded = {
             "combat": (actorData.data.settings?.combat) ? actorData.data.settings?.combat.folded : [],
             "inventory": (actorData.data.settings?.inventory) ? actorData.data.settings?.inventory.folded : [],
             "capacities": (actorData.data.settings?.capacities) ? actorData.data.settings?.capacities.folded : [],
             "effects": (actorData.data.settings?.effects) ? actorData.data.settings?.effects.folded : []
-        };        
+        };
         data.actor = actorData;
-        data.data = actorData.data;       
+        data.data = actorData.data;
 
         return data;
 	}

--- a/module/actors/encounter-sheet.js
+++ b/module/actors/encounter-sheet.js
@@ -35,7 +35,7 @@ export class CoCEncounterSheet extends CoCBaseSheet {
 
         // Combat and Inventory
         data.inventory = data.items.filter(i => i.type === "item");
-        data.capacities = data.items.filter(i => i.type === "capacity");        
+        data.capacities = data.items.filter(i => i.type === "capacity");
 
         data.weapons = data.items.filter(item=>item.type === "encounterWeapon");
         data.weapons.forEach((weapon)=>{

--- a/module/actors/encounter-sheet.js
+++ b/module/actors/encounter-sheet.js
@@ -39,9 +39,9 @@ export class CoCEncounterSheet extends CoCBaseSheet {
 
         data.weapons = data.items.filter(item=>item.type === "encounterWeapon");
         data.weapons.forEach((weapon)=>{
-            weapon.data.weapon.modTotal = weapon.data.weapon.mod + weapon.data.weapon.skillBonus;
-            weapon.data.weapon.dmgTotal = weapon.data.weapon.dmg;
-            if (weapon.data.weapon.dmgBonus > 0) weapon.data.weapon.dmgTotal += ` + ${weapon.data.weapon.dmgBonus}`;
+            weapon.system.weapon.modTotal = weapon.system.weapon.mod + weapon.system.weapon.skillBonus;
+            weapon.system.weapon.dmgTotal = weapon.system.weapon.dmg;
+            if (weapon.system.weapon.dmgBonus > 0) weapon.system.weapon.dmgTotal += ` + ${weapon.system.weapon.dmgBonus}`;
         });
 
         // Gestion des boutons de modification des effets (visible pour l'encounter)

--- a/module/actors/npc-sheet.js
+++ b/module/actors/npc-sheet.js
@@ -19,7 +19,7 @@ export class CoCNpcSheet extends CoCBaseSheet {
     getData(options) {
         const data = super.getData(options);
         if (COC.debug) console.log("COC | NpcSheet getData", data);
-        
+
         // The Actor's data
         const actorData = this.actor.data.toObject(false);
 

--- a/module/actors/npc-sheet.js
+++ b/module/actors/npc-sheet.js
@@ -21,7 +21,7 @@ export class CoCNpcSheet extends CoCBaseSheet {
         if (COC.debug) console.log("COC | NpcSheet getData", data);
 
         // The Actor's data
-        const actorData = this.actor.data.toObject(false);
+        const actorData = this.actor.toObject(false);
 
         // Owned Items
         data.profile = actorData.items.find(item => item.type === "profile");
@@ -39,18 +39,18 @@ export class CoCNpcSheet extends CoCBaseSheet {
             id: "standalone-capacities",
             label: "Capacités Hors-Voies",
             items: Object.values(actorData.items).filter(item => {
-                if (item.type === "capacity" && item.data.path.key === "") {
+                if (item.type === "capacity" && item.system.path.key === "") {
                     return true;
                 }
             }).sort((a, b) => (a.name > b.name) ? 1 : -1)
         });
         for (const path of paths) {
             data.capacities.collections.push({
-                id: (path.data.key) ? path.data.key : path.name.slugify({ strict: true }),
+                id: (path.system.key) ? path.system.key : path.name.slugify({ strict: true }),
                 label: path.name,
                 items: Object.values(actorData.items).filter(item => {
-                    if (item.type === "capacity" && item.data.path._id === path._id) return true;
-                }).sort((a, b) => (a.data.rank > b.data.rank) ? 1 : -1)
+                    if (item.type === "capacity" && item.system.path._id === path._id) return true;
+                }).sort((a, b) => (a.system.rank > b.system.rank) ? 1 : -1)
             });
         }
 
@@ -67,7 +67,7 @@ export class CoCNpcSheet extends CoCBaseSheet {
 
         // Combat and Inventory
         data.combat = {
-            count: data.items.filter(i => i.data.worn).length,
+            count: data.items.filter(i => i.system.worn).length,
             categories: []
         };
         data.inventory = {
@@ -78,31 +78,31 @@ export class CoCNpcSheet extends CoCBaseSheet {
             data.combat.categories.push({
                 id: category,
                 label: game.coc.config.itemCategories[category],
-                items: Object.values(data.items).filter(item => item.type === "item" && item.data.subtype === category && item.data.worn).sort((a, b) => (a.name > b.name) ? 1 : -1)
+                items: Object.values(data.items).filter(item => item.type === "item" && item.system.subtype === category && item.system.worn).sort((a, b) => (a.name > b.name) ? 1 : -1)
             });
             data.inventory.categories.push({
                 id: category,
                 label: "COC.category." + category,
-                items: Object.values(data.items).filter(item => item.type === "item" && item.data.subtype === category).sort((a, b) => (a.name > b.name) ? 1 : -1)
+                items: Object.values(data.items).filter(item => item.type === "item" && item.system.subtype === category).sort((a, b) => (a.name > b.name) ? 1 : -1)
             });
         }
 
         data.combat.categories.forEach(category => {
             if (category.items.length > 0) {
                 category.items.forEach(item => {
-                    if (item.data.properties?.weapon) {
+                    if (item.system.properties?.weapon) {
                         // Compute MOD
-                        const itemModStat = item.data.skill.split("@")[1];
-                        const itemModBonus = parseInt(item.data.skillBonus);
+                        const itemModStat = item.system.skill.split("@")[1];
+                        const itemModBonus = parseInt(item.system.skillBonus);
 
-                        item.data.mod = this.actor.computeWeaponMod(itemModStat, itemModBonus);
+                        item.system.mod = this.actor.computeWeaponMod(itemModStat, itemModBonus);
 
                         // Compute DM
-                        const itemDmgBase = item.data.dmgBase;
-                        const itemDmgStat = item.data.dmgStat.split("@")[1];
-                        const itemDmgBonus = parseInt(item.data.dmgBonus);
+                        const itemDmgBase = item.system.dmgBase;
+                        const itemDmgStat = item.system.dmgStat.split("@")[1];
+                        const itemDmgBonus = parseInt(item.system.dmgBonus);
 
-                        item.data.dmg = this.actor.computeDm(itemDmgBase, itemDmgStat, itemDmgBonus)
+                        item.dmg = this.actor.computeDm(itemDmgBase, itemDmgStat, itemDmgBonus)
                     }
                 });
             }

--- a/module/coc.js
+++ b/module/coc.js
@@ -28,7 +28,7 @@ import {UpdateUtils} from "./utils/update-utils.js";
 Hooks.once("init", function () {
 
     console.info("COC | "+ System.label + " | System Initializing...");
-    console.info(System.ASCII);  
+    console.info(System.ASCII);
 
     // Register System Settings
     registerSystemSettings();
@@ -48,7 +48,7 @@ Hooks.once("init", function () {
         decimals: 2
       };
     }
-   
+
     // Record Configuration values
     CONFIG.COC = COC;
 
@@ -75,7 +75,7 @@ Hooks.once("init", function () {
     Actors.registerSheet("coc", CoCEncounterSheet, {types: ["encounter"], makeDefault: false, label: "COC.sheet.encounter"});
 
     // Register item sheets
-    Items.registerSheet("coc", CoCItemSheet, {types: ["item", "trait", "capacity", "profile", "path", "encounterWeapon"], makeDefault: false, label: "COC.sheet.item"});    
+    Items.registerSheet("coc", CoCItemSheet, {types: ["item", "trait", "capacity", "profile", "path", "encounterWeapon"], makeDefault: false, label: "COC.sheet.item"});
 
     // Preload Handlebars Templates
     preloadHandlebarsTemplates();

--- a/module/controllers/capacity.js
+++ b/module/controllers/capacity.js
@@ -18,9 +18,9 @@ export class Capacity {
 
     /**
      * Supprime une capacité de la feuille de personnage et met à jour les infos d'un éventuel path
-     * @param {*} actor 
-     * @param {*} capacity 
-     * @returns 
+     * @param {*} actor
+     * @param {*} capacity
+     * @returns
      */
      static removeFromActor(actor, capacity) {
         const capacityData = capacity.data;
@@ -50,10 +50,10 @@ export class Capacity {
 
 
    /**
-     * 
-     * @param {*} entity 
-     * @param {*} capacityData 
-     * @returns 
+     *
+     * @param {*} entity
+     * @param {*} capacityData
+     * @returns
      */
     static addToItem(entity, capacityData) {
         let data = duplicate(entity.data);
@@ -65,7 +65,7 @@ export class Capacity {
         }
         else ui.notifications.error("Cet objet contient déjà cette capacité.")
     }
-    
+
     /**
      *
      * @param {*} actor
@@ -132,5 +132,5 @@ export class Capacity {
             });
         });
     }
- 
+
 }

--- a/module/controllers/dmg-roll.js
+++ b/module/controllers/dmg-roll.js
@@ -10,9 +10,9 @@ export class DamageRoll {
         const r = new Roll(this._formula);
         // Manage explosive dice
         if (game.settings.get("coc","explosiveDice")) {
-            r.dice.forEach((die)=>{             
+            r.dice.forEach((die)=>{
                 if (!die.modifiers.includes("x")) die.modifiers.push("x");
-            });    
+            });
         }
         await r.roll({"async": true});
         if (this._isCritical) r._total = r._total * 2;

--- a/module/controllers/healing-roll.js
+++ b/module/controllers/healing-roll.js
@@ -8,7 +8,7 @@ export class CocHealingRoll {
     }
 
     async roll(actor){
-        const r = new Roll(this._formula,actor.data.data);
+        const r = new Roll(this._formula, actor.system);
         await r.roll({"async": true});
         if (this._isCritical) r._total = r._total * 2;
         this._buildHealingRollMessage().then(msgFlavor => {

--- a/module/controllers/hitpoints.js
+++ b/module/controllers/hitpoints.js
@@ -7,10 +7,10 @@ export class Hitpoints {
             ui.notifications.error("Vous devez sélectionner au moins une cible pour appliquer les dégâts.");
         } else {
             for(let target of targets){
-                let data = duplicate(target.actor.data);
-                let hp = data.data.attributes.hp;
+                let data = duplicate(target.actor);
+                let hp = data.system.attributes.hp;
                 // Application de la RD si c'est cochée
-                const finalAmount = amount + (dr ? data.data.attributes.dr.value : 0);
+                const finalAmount = amount + (dr ? target.actor.system.attributes.dr.value : 0);
                 hp.value += finalAmount;
 
                 target.actor.update(data);

--- a/module/controllers/inventory.js
+++ b/module/controllers/inventory.js
@@ -9,8 +9,8 @@ export class Inventory {
         const item = actor.items.get(li.data("itemId"));
         const consumable = li.data("itemConsumable");
         if(consumable){
-            let itemData = duplicate(item.data);
-            itemData.data.qty = (itemData.data.qty > 0) ? itemData.data.qty - 1 : 0;
+            let itemData = duplicate(item);
+            itemData.system.qty = (itemData.system.qty > 0) ? itemData.system.qty - 1 : 0;
             return item.update(itemData).then(i=> item.applyEffects(actor, event));
             // return actor.updateOwnedItem(itemData);
         }

--- a/module/controllers/path.js
+++ b/module/controllers/path.js
@@ -18,19 +18,19 @@ export class Path {
             let updatedPaths = newPaths.map(newPath => {
                 const index = newPaths.indexOf(newPath);
                 let updatedPath = duplicate(newPath);
-                updatedPath.data.capacities = updatedPath.data.capacities.map(cap => {
+                updatedPath.system.capacities = updatedPath.system.capacities.map(cap => {
                     // Ajout de données utilisées pour la gestion des voies/capa
                     cap.data = {
                         key: cap.name.slugify({ strict: true }),
-                        rank: updatedPath.data.capacities.indexOf(cap) + 1,
+                        rank: updatedPath.system.capacities.indexOf(cap) + 1,
                         sourceId: cap.sourceId,
                         checked: false,
                         path: {
                             _id: updatedPath._id,
                             name: updatedPath.name,
                             img: updatedPath.img,
-                            key: updatedPath.data.key,
-                            sourceId: pathsData[index].sourceId,
+                            key: updatedPath.system.key,
+                            sourceId: pathsData[index].flags.core.sourceId,
                         }
                     };
                     return cap;
@@ -49,7 +49,7 @@ export class Path {
      * @returns
      */
     static addToActor(actor, pathData) {
-        if (actor.items.filter(item => item.type === "path" && item.data.name === pathData.name).length > 0) {
+        if (actor.items.filter(item => item.type === "path" && item.name === pathData.name).length > 0) {
             ui.notifications.error("Vous possédez déjà cette voie.");
             return false;
         } else {
@@ -60,16 +60,16 @@ export class Path {
     static getPathsFromActorByKey(actor, pathKeys) {
         const start = performance.now();
         let items = [];
-        const ownedPaths = actor.items.filter(item => pathKeys.includes(item.data.data.key) && item.data.type === "path");
+        const ownedPaths = actor.items.filter(item => pathKeys.includes(item.system.key) && item.type === "path");
         if(ownedPaths.length>0){
-            const ownedPathsIds = ownedPaths.map(c => c.data._id);
-            const ownedPathsCapacities = ownedPaths.map(c => c.data.data.capacities).flat();
+            const ownedPathsIds = ownedPaths.map(c => c._id);
+            const ownedPathsCapacities = ownedPaths.map(c => c.system.capacities).flat();
             // retrieve owned capacities matching profile paths capacities
             const allCaps = Traversal.getItemsOfType("capacity");
             const pathCaps = allCaps.filter(p => { if(p && p._id && ownedPathsCapacities.includes(p._id)) return ownedPathsCapacities.includes(p._id) });
             if(pathCaps.length > 0){
-                const pathCapsKeys = pathCaps.map(c => c.data.key);
-                const capsIds = actor.items.filter(item => pathCapsKeys.includes(item.data.data.key) && item.data.type === "capacity").map(c => c.data._id);
+                const pathCapsKeys = pathCaps.map(c => c.system.key);
+                const capsIds = actor.items.filter(item => pathCapsKeys.includes(item.system.key) && item.type === "capacity").map(c => c._id);
                 items = items.concat(capsIds);
             }
             items = items.concat(ownedPathsIds);
@@ -87,11 +87,11 @@ export class Path {
      * @returns
      */
      static addToItem(entity, pathData) {
-        let data = duplicate(entity.data);
-        let paths = data.data.paths;
+        let data = duplicate(entity);
+        let paths = data.system.paths;
         let pathsIds = paths.map(p => p._id);
         if (pathsIds && !pathsIds.includes(pathData._id)) {
-            data.data.paths.push(EntitySummary.create(pathData));
+            data.system.paths.push(EntitySummary.create(pathData));
             return entity.update(data);
         }
         else ui.notifications.error("Cet objet contient déjà cette voie.")
@@ -102,8 +102,8 @@ export class Path {
             title: "Supprimer une voie",
             content: `<p>Etes-vous sûr de vouloir supprimer la ${entity.name} de ${actor.name} ?</p>`,
             yes: () => {
-                const pathData = entity.data;
-                let items = actor.items.filter(item => item.data.type === "capacity" && item.data.data.path._id === pathData._id).map(c => c.data._id);
+                const pathData = entity;
+                let items = actor.items.filter(item => item.type === "capacity" && item.system.path._id === pathData._id).map(c => c._id);
                 items.push(entity.id);
                 return actor.deleteEmbeddedDocuments("Item", items);
             },
@@ -122,8 +122,8 @@ export class Path {
         paths = paths instanceof Array ? paths : [paths];
         paths.map(path => {
             let caps = actor.items.filter(item => {
-                if (item.data.type === "capacity") {
-                    if (item.data.data.path._id === path.id) return true;
+                if (item.type === "capacity") {
+                    if (item.system.path._id === path.id) return true;
                 }
             });
             caps.map(c => items.push(c.id));

--- a/module/controllers/path.js
+++ b/module/controllers/path.js
@@ -11,7 +11,7 @@ export class Path {
      */
     static addPathsToActor(actor, pathsData) {
         let items = [];
-        pathsData = pathsData instanceof Array ? pathsData : [pathsData];   
+        pathsData = pathsData instanceof Array ? pathsData : [pathsData];
         pathsData.forEach(p => { items.push(p.toObject(false)) });
         return actor.createEmbeddedDocuments("Item", items).then(newPaths => {
             // on ajoute toutes les metadonnees aux voies nouvellement creees pour faciliter la gestions des capacites qui en dependent
@@ -56,7 +56,7 @@ export class Path {
             return this.addPathsToActor(actor, [pathData]);
         }
     }
-    
+
     static getPathsFromActorByKey(actor, pathKeys) {
         const start = performance.now();
         let items = [];
@@ -81,10 +81,10 @@ export class Path {
     }
 
     /**
-     * 
-     * @param {*} entity 
-     * @param {*} pathData 
-     * @returns 
+     *
+     * @param {*} entity
+     * @param {*} pathData
+     * @returns
      */
      static addToItem(entity, pathData) {
         let data = duplicate(entity.data);
@@ -97,7 +97,7 @@ export class Path {
         else ui.notifications.error("Cet objet contient déjà cette voie.")
     }
 
-    static removeFromActor(actor, entity) {        
+    static removeFromActor(actor, entity) {
         Dialog.confirm({
             title: "Supprimer une voie",
             content: `<p>Etes-vous sûr de vouloir supprimer la ${entity.name} de ${actor.name} ?</p>`,
@@ -112,10 +112,10 @@ export class Path {
     }
 
     /**
-     * 
-     * @param {*} actor 
-     * @param {*} paths 
-     * @returns 
+     *
+     * @param {*} actor
+     * @param {*} paths
+     * @returns
      */
     static removePathsFromActor(actor, paths) {
         let items = [];

--- a/module/controllers/profile.js
+++ b/module/controllers/profile.js
@@ -11,22 +11,22 @@ export class Profile {
 
             // ajoute le profil dans Items
             return actor.createEmbeddedDocuments("Item", [itemData], {}).then(newProfile => {
-                let newProfileData = newProfile[0].data;
+                let newProfileData = newProfile[0];
                 return Traversal.mapItemsOfType(["path"]).then(paths => {
-                    newProfileData.data.paths = newProfileData.data.paths.map(p => {
+                    newProfileData.system.paths = newProfileData.system.paths.map(p => {
                         let pathData = paths[p._id];
                         pathData.flags.core = { sourceId: p.sourceId };
-                        pathData.data.profile = {
+                        pathData.system.profile = {
                             _id: newProfileData._id,
                             name: newProfileData.name,
                             img: newProfileData.img,
-                            key: newProfileData.data.key,
+                            key: newProfileData.system.key,
                             sourceId: newProfileData.flags.core.sourceId,
                         };
                         return pathData;
                     });
                     // add paths from profile
-                    return Path.addPathsToActor(actor, newProfileData.data.paths)
+                    return Path.addPathsToActor(actor, newProfileData.system.paths)
                 });
             });
         }
@@ -42,7 +42,7 @@ export class Profile {
      * @returns
      */
     static removeFromActor(actor, profile) {
-        const paths = actor.items.filter(item => item.type === "path" && item.data.data.profile?._id === profile.id);
+        const paths = actor.items.filter(item => item.type === "path" && item.system.profile?._id === profile.id);
         return Dialog.confirm({
             title: "Supprimer le profil",
             content: `<p>Etes-vous sûr de vouloir supprimer le profil de ${actor.name} ?</p>`,

--- a/module/controllers/profile.js
+++ b/module/controllers/profile.js
@@ -35,11 +35,11 @@ export class Profile {
      /**
      * @name removeFromActor
      * @description Supprime le profil et ses voies de l'acteur en paramètre
-     * @public @static 
-     * 
+     * @public @static
+     *
      * @param {CocActor} actor l'acteur sur lequel supprimer le profil
      * @param {CocItem} profile l'item profil à supprimer
-     * @returns 
+     * @returns
      */
     static removeFromActor(actor, profile) {
         const paths = actor.items.filter(item => item.type === "path" && item.data.data.profile?._id === profile.id);

--- a/module/controllers/roll.js
+++ b/module/controllers/roll.js
@@ -10,13 +10,13 @@ export class CoCRoll {
 
     /**
      * @name skillCheck
-     * @description  Jet de compétence 
-     * 
-     * @param {*} data 
-     * @param {*} actor 
-     * @param {*} event 
-     * @returns 
-     */  
+     * @description  Jet de compétence
+     *
+     * @param {*} data
+     * @param {*} actor
+     * @param {*} event
+     * @returns
+     */
     static skillCheck(data, actor, event) {
         const elt = $(event.currentTarget)[0];
         let key = elt.attributes["data-rolling"].value;
@@ -24,8 +24,8 @@ export class CoCRoll {
 
         const mod = eval(`${key}.mod`);
         const tmpmod = eval(`${key}.tmpmod`);
-        
-        let bonus = eval(`${key}.skillbonus`);        
+
+        let bonus = eval(`${key}.skillbonus`);
         if (!bonus) bonus = 0;
 
         let malus = 0;
@@ -41,18 +41,18 @@ export class CoCRoll {
 
     /**
      * @name rollWeapon
-     * @description  Jet d'attaque 
-     * 
-     * @param {*} data 
-     * @param {*} actor 
-     * @param {*} event 
-     * @returns 
-     */    
+     * @description  Jet d'attaque
+     *
+     * @param {*} data
+     * @param {*} actor
+     * @param {*} event
+     * @returns
+     */
     static rollWeapon(data, actor, event) {
-        const li = $(event.currentTarget).parents(".item");        
+        const li = $(event.currentTarget).parents(".item");
         let item = actor.items.get(li.data("itemId"));
         const itemData = item.data;
-    
+
         const label = itemData.name;
         const critrange = itemData.data.critrange;
         const itemMod = $(event.currentTarget).parents().children(".item-mod");
@@ -65,13 +65,13 @@ export class CoCRoll {
 
     /**
      * @name rollDamage
-     * @description  Jet de dommages 
-     * 
-     * @param {*} data 
-     * @param {*} actor 
-     * @param {*} event 
-     * @returns 
-     */  
+     * @description  Jet de dommages
+     *
+     * @param {*} data
+     * @param {*} actor
+     * @param {*} event
+     * @returns
+     */
      static rollDamage(data, actor, event) {
         const li = $(event.currentTarget).parents(".item");
         let item = actor.items.get(li.data("itemId"));
@@ -79,7 +79,7 @@ export class CoCRoll {
         let dmg = item.data.data.dmg;
         return this.rollDamageDialog(actor, label, dmg, 0);
     }
-        
+
     /**
      *  Handles spell rolls
      * @param elt DOM element which raised the roll event
@@ -163,11 +163,11 @@ export class CoCRoll {
     /**
      * @name rollAttributes
      * @description Handles attributes rolls
-     * 
-     * @param {*} data 
-     * @param {*} actor 
-     * @param {*} event 
-     * @returns 
+     *
+     * @param {*} data
+     * @param {*} actor
+     * @param {*} event
+     * @returns
      */
     static async rollAttributes(data, actor, event) {
         let stats = data.stats;
@@ -191,29 +191,29 @@ export class CoCRoll {
      * @name rollEncounterWeapon
      * @description  Jet d'attaque d'une rencontre
      *  Basé sur les valeurs affichées sur la fiche
-     * 
-     * @param {*} data 
-     * @param {*} actor 
-     * @param {*} event 
-     * @returns 
+     *
+     * @param {*} data
+     * @param {*} actor
+     * @param {*} event
+     * @returns
      */
     static rollEncounterWeapon(data, actor, event) {
         const weapon = $(event.currentTarget).parents(".item");
         let label = weapon.find(".weapon-name").text();
-        let critrange = weapon.find(".weapon-crit").text();        
+        let critrange = weapon.find(".weapon-crit").text();
         let mod = weapon.find(".weapon-mod").text();
         let dmg = weapon.find(".weapon-dmg").text();
         return this.rollWeaponDialog(actor, label, mod, 0, 0, critrange, dmg, 0);
     }
-    
+
     /**
      * @name rollEncounterDamage
      * @description  Jet de dommages d'une rencontre
      *  Basé sur les valeurs affichées sur la fiche
-     * 
-     * @param {*} data 
-     * @param {*} actor 
-     * @param {*} event 
+     *
+     * @param {*} data
+     * @param {*} actor
+     * @param {*} event
      * @returns
      */
     static rollEncounterDamage(data, actor, event) {
@@ -237,9 +237,9 @@ export class CoCRoll {
         const isDifficultyDisplayed = displayDifficulty === "all" || (displayDifficulty === "gm" && game.user.isGM);
         const rollOptionContent = await renderTemplate(rollOptionTpl, {
             mod: mod,
-            bonus: bonus, 
-            malus: malus, 
-            critrange: critrange, 
+            bonus: bonus,
+            malus: malus,
+            critrange: critrange,
             superior:superior,
             difficulty: diff,
             displayDifficulty: isDifficultyDisplayed
@@ -276,16 +276,16 @@ export class CoCRoll {
     }
 
     /**
-     * 
-     * @param {*} actor 
-     * @param {*} label 
-     * @param {*} mod 
-     * @param {*} bonus 
-     * @param {*} critrange 
-     * @param {*} dmgFormula 
-     * @param {*} dmgBonus 
-     * @param {*} onEnter 
-     * @returns 
+     *
+     * @param {*} actor
+     * @param {*} label
+     * @param {*} mod
+     * @param {*} bonus
+     * @param {*} critrange
+     * @param {*} dmgFormula
+     * @param {*} dmgBonus
+     * @param {*} onEnter
+     * @returns
      */
      static async rollWeaponDialog(actor, label, mod, bonus, malus, critrange, dmgFormula, dmgBonus, onEnter = "submit", skillDescr, dmgDescr, difficulty = null) {
         const rollOptionTpl = 'systems/coc/templates/dialogs/roll-weapon-dialog.hbs';
@@ -293,7 +293,7 @@ export class CoCRoll {
         let isDifficultyDisplayed = true;
 
         if (difficulty !== null) {
-            diff = difficulty;   
+            diff = difficulty;
         }
         else {
             const displayDifficulty = game.settings.get("coc", "displayDifficulty");
@@ -441,11 +441,11 @@ export class CoCRoll {
 
    /**
      *  Handles recovery roll
-     * 
-     * @param {*} data 
-     * @param {*} actor 
+     *
+     * @param {*} data
+     * @param {*} actor
      * @param {*} withHPrecovery true to Get HitPoints
-     * @returns 
+     * @returns
      */
     static rollRecoveryUse(data, actor, withHPrecovery) {
         let recoveryPoints = data.attributes.rp.value;
@@ -456,7 +456,7 @@ export class CoCRoll {
         const level = data.level.value;
         const conMod = data.stats.con.mod;
         const actorData = actor.data;
-    
+
         if (!withHPrecovery) {
             rp.value -= 1;
             actor.update({ 'data.attributes.rp': rp });
@@ -471,17 +471,17 @@ export class CoCRoll {
                         const hdmax = parseInt(hd.split("d")[1]);
                         const bonus = level + conMod;
                         const formula = `1d${hdmax} + ${bonus}`;
-                        
+
                         let healingRoll = new CocHealingRoll("", formula, false, "Point de récupération", false);
                         let result = await healingRoll.roll(actor);
-    
+
                         hp.value += result.total;
                         rp.value -= 1;
                         actor.update({ 'data.attributes.hp': hp, 'data.attributes.rp': rp });
                 },
                 defaultYes: false
             });
-        }   
+        }
     }
 
 }

--- a/module/controllers/skill-roll.js
+++ b/module/controllers/skill-roll.js
@@ -42,12 +42,12 @@ export class SkillRoll {
     /**
      * @name weaponRoll
      * @description Jet de dommages d'une arme
-     * 
-     * @param {*} actor 
-     * @param {*} dmgFormula 
-     * @param {*} dmgDescr 
-     * @returns 
-     */    
+     *
+     * @param {*} actor
+     * @param {*} dmgFormula
+     * @param {*} dmgDescr
+     * @returns
+     */
    async weaponRoll(actor, dmgFormula, dmgDescr){
         await this.roll(actor);
         if (this._difficulty) {
@@ -77,7 +77,7 @@ export class SkillRoll {
             isSuccess : this._isSuccess,
             isFailure : !this._isSuccess,
             hasDescription : this._description && this._description.length > 0,
-			description : this._description       
+			description : this._description
         };
         return renderTemplate(rollMessageTpl, tplData);
     }

--- a/module/items/item-sheet.js
+++ b/module/items/item-sheet.js
@@ -252,7 +252,7 @@ export class CoCItemSheet extends ItemSheet {
     /** @override */
     getData(options) {
         const data = super.getData(options);
-        
+
         let lockItems = game.settings.get("coc", "lockItems");
         options.editable &= (game.user.isGM || !lockItems);
 
@@ -267,8 +267,8 @@ export class CoCItemSheet extends ItemSheet {
         data.isEffectsEditable = !this.item.actor && options.editable;
         data.item = itemData;
         data.data = itemData.data;
-        
-        return data;       
+
+        return data;
     }
 
     /* -------------------------------------------- */
@@ -292,9 +292,9 @@ export class CoCItemSheet extends ItemSheet {
     }
 
     /**
-     * 
-     * @param {*} event 
-     * @returns 
+     *
+     * @param {*} event
+     * @returns
      */
      _onVerifyCheckboxes(event){
         const input = $(event.currentTarget).find("input");
@@ -315,7 +315,7 @@ export class CoCItemSheet extends ItemSheet {
             data.data.value = 0;
             data.data.rarity = "";
             return this.item.update(data);
-        }        
+        }
         if (name === "data.properties.equipable" && !checked) {
             let data = duplicate(this.item.data);
             data.data.slot = "";
@@ -351,13 +351,13 @@ export class CoCItemSheet extends ItemSheet {
             let data = duplicate(this.item.data);
             data.data.dr = 0;
             return this.item.update(data);
-        }        
+        }
         if (name === "data.properties.ranged" && !checked) {
             let data = duplicate(this.item.data);
             data.data.range = 0;
             data.data.properties.reloadable = false;
             data.data.properties.salve = false;
-            data.data.properties.proneshot = false;            
+            data.data.properties.proneshot = false;
             data.data.properties.explosive = false;
             data.data.reload = "";
             return this.item.update(data);
@@ -366,7 +366,7 @@ export class CoCItemSheet extends ItemSheet {
             let data = duplicate(this.item.data);
             data.data.reload = "";
             return this.item.update(data);
-        }        
+        }
         if (name === "data.properties.effects" && !checked) {
             let data = duplicate(this.item.data);
             data.data.properties.heal = false;
@@ -401,6 +401,6 @@ export class CoCItemSheet extends ItemSheet {
             let data = duplicate(this.item.data);
             data.data.properties.activable = false;
             return this.item.update(data);
-        }        
+        }
     }
 }

--- a/module/items/item-sheet.js
+++ b/module/items/item-sheet.js
@@ -51,7 +51,10 @@ export class CoCItemSheet extends ItemSheet {
         html.find('.coc-compendium-pack').click(ev => {
             ev.preventDefault();
             let li = $(ev.currentTarget), pack = game.packs.get(li.data("pack"));
-            if ( li.attr("data-open") === "1" ) pack.close();
+            if ( li.attr("data-open") === "1" ) {
+                li.attr("data-open", "0");
+                pack.apps[0].close();
+            }
             else {
                 li.attr("data-open", "1");
                 li.find("i.folder").removeClass("fa-folder").addClass("fa-folder-open");
@@ -115,7 +118,7 @@ export class CoCItemSheet extends ItemSheet {
             const effectId = elt.data("itemId");
             let effect = this.item.effects.get(effectId);
             if (effect) {
-                effect.update({ disabled: !effect.data.disabled })
+                effect.update({ disabled: !effect.disabled })
             }
         });
 
@@ -167,7 +170,7 @@ export class CoCItemSheet extends ItemSheet {
      */
     async _onDropItem(event, data) {
         Item.fromDropData(data).then(item => {
-            const itemData = duplicate(item.data);
+            const itemData = duplicate(item);
             switch (itemData.type) {
                 case "path": return this._onDropPathItem(event, itemData);
                 case "capacity": return this._onDropCapacityItem(event, itemData);
@@ -198,7 +201,7 @@ export class CoCItemSheet extends ItemSheet {
 
     _onDropPathItem(event, itemData) {
         event.preventDefault();
-        if (this.item.data.type === "profile") return Path.addToItem(this.item, itemData);
+        if (this.item.type === "profile") return Path.addToItem(this.item, itemData);
         else return false;
     }
 
@@ -206,7 +209,7 @@ export class CoCItemSheet extends ItemSheet {
 
     _onDropCapacityItem(event, itemData) {
         event.preventDefault();
-        if (this.item.data.type === "path") return Capacity.addToItem(this.item, itemData);
+        if (this.item.type === "path") return Capacity.addToItem(this.item, itemData);
         else return false;
     }
 
@@ -233,14 +236,14 @@ export class CoCItemSheet extends ItemSheet {
 
     _onDeleteItem(ev){
         ev.preventDefault();
-        let data = duplicate(this.item.data);
+        let data = duplicate(this.item);
         const li = $(ev.currentTarget).closest(".item");
         const id = li.data("itemId");
         const itemType = li.data("itemType");
         let array = null;
         switch(itemType){
-            case "path" : array = data.data.paths; break;
-            case "capacity" : array = data.data.capacities; break;
+            case "path" : array = data.system.paths; break;
+            case "capacity" : array = data.system.capacities; break;
         }
         const item = array.find(e => e._id === id);
         if(array && array.includes(item)) {
@@ -266,7 +269,7 @@ export class CoCItemSheet extends ItemSheet {
         // Les boutons sont masqués si l'item appartient à un actor
         data.isEffectsEditable = !this.item.actor && options.editable;
         data.item = itemData;
-        data.data = itemData.data;
+        data.system = itemData.system;
 
         return data;
     }
@@ -283,7 +286,7 @@ export class CoCItemSheet extends ItemSheet {
         // const labels = this.item.labels;
 
         if ( item.type === "item" ) {
-            const entries = Object.entries(item.data.data.properties)
+            const entries = Object.entries(item.system.properties)
             props.push(...entries.filter(e => e[1] === true).map(e => {
                 return game.coc.config.itemProperties[e[0]]
             }));
@@ -300,106 +303,106 @@ export class CoCItemSheet extends ItemSheet {
         const input = $(event.currentTarget).find("input");
         const name = input.attr('name');
         const checked = input.prop('checked')
-        if (name === "data.properties.equipment" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.properties.equipable = false;
-            data.data.slot = "";
-            data.data.properties.stackable = false;
-            data.data.qty = 1;
-            data.data.stacksize = null;
-            data.data.properties.unique = false;
-            data.data.properties.consumable = false;
-            data.data.properties.tailored = false;
-            data.data.properties["2H"] = false;
-            data.data.price = 0;
-            data.data.value = 0;
-            data.data.rarity = "";
+        if (name === "system.properties.equipment" && !checked) {
+            let data = duplicate(this.item);
+            data.system.properties.equipable = false;
+            data.system.slot = "";
+            data.system.properties.stackable = false;
+            data.system.qty = 1;
+            data.system.stacksize = null;
+            data.system.properties.unique = false;
+            data.system.properties.consumable = false;
+            data.system.properties.tailored = false;
+            data.system.properties["2H"] = false;
+            data.system.price = 0;
+            data.system.value = 0;
+            data.system.rarity = "";
             return this.item.update(data);
         }
-        if (name === "data.properties.equipable" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.slot = "";
+        if (name === "system.properties.equipable" && !checked) {
+            let data = duplicate(this.item);
+            data.system.slot = "";
             return this.item.update(data);
         }
-        if (name === "data.properties.stackable" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.qty = 1;
-            data.data.stacksize = null;
+        if (name === "system.properties.stackable" && !checked) {
+            let data = duplicate(this.item);
+            data.system.qty = 1;
+            data.system.stacksize = null;
             return this.item.update(data);
         }
-        if (name === "data.properties.weapon" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.skill = "@attacks.melee.mod";
-            data.data.skillBonus = 0;
-            data.data.dmgBase = 0;
-            data.data.dmgStat = "";
-            data.data.dmgBonus = 0;
-            data.data.critrange = "20"
-            data.data.properties.bashing = false;
-            data.data.properties["13strmin"] = false;
+        if (name === "system.properties.weapon" && !checked) {
+            let data = duplicate(this.item);
+            data.system.skill = "@attacks.melee.mod";
+            data.system.skillBonus = 0;
+            data.system.dmgBase = 0;
+            data.system.dmgStat = "";
+            data.system.dmgBonus = 0;
+            data.system.critrange = "20"
+            data.system.properties.bashing = false;
+            data.system.properties["13strmin"] = false;
             return this.item.update(data);
         }
-        if (name === "data.properties.protection" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.defBase = 0;
-            data.data.defBonus = 0;
-            data.data.properties.dr = false;
-            data.data.dr = 0;
+        if (name === "system.properties.protection" && !checked) {
+            let data = duplicate(this.item);
+            data.system.defBase = 0;
+            data.system.defBonus = 0;
+            data.system.properties.dr = false;
+            data.system.dr = 0;
             return this.item.update(data);
         }
-        if (name === "data.properties.dr" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.dr = 0;
+        if (name === "system.properties.dr" && !checked) {
+            let data = duplicate(this.item);
+            data.system.dr = 0;
             return this.item.update(data);
         }
-        if (name === "data.properties.ranged" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.range = 0;
-            data.data.properties.reloadable = false;
-            data.data.properties.salve = false;
-            data.data.properties.proneshot = false;
-            data.data.properties.explosive = false;
-            data.data.reload = "";
+        if (name === "system.properties.ranged" && !checked) {
+            let data = duplicate(this.item);
+            data.system.range = 0;
+            data.system.properties.reloadable = false;
+            data.system.properties.salve = false;
+            data.system.properties.proneshot = false;
+            data.system.properties.explosive = false;
+            data.system.reload = "";
             return this.item.update(data);
         }
-        if (name === "data.properties.reloadable" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.reload = "";
+        if (name === "system.properties.reloadable" && !checked) {
+            let data = duplicate(this.item);
+            data.system.reload = "";
             return this.item.update(data);
         }
-        if (name === "data.properties.effects" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.properties.heal = false;
-            data.data.properties.buff = false;
-            data.data.properties.temporary = false;
-            data.data.properties.persistent = false;
-            data.data.properties.spell = false;
-            data.data.effects.heal.formula = null;
-            data.data.effects.buff.formula = null;
-            data.data.properties.duration.formula = null;
-            data.data.properties.duration.units = "";
-            data.data.properties.activable = false;
+        if (name === "system.properties.effects" && !checked) {
+            let data = duplicate(this.item);
+            data.system.properties.heal = false;
+            data.system.properties.buff = false;
+            data.system.properties.temporary = false;
+            data.system.properties.persistent = false;
+            data.system.properties.spell = false;
+            data.system.effects.heal.formula = null;
+            data.system.effects.buff.formula = null;
+            data.system.properties.duration.formula = null;
+            data.system.properties.duration.units = "";
+            data.system.properties.activable = false;
             return this.item.update(data);
         }
-        if (name === "data.properties.heal" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.effects.heal.formula = null;
+        if (name === "system.properties.heal" && !checked) {
+            let data = duplicate(this.item);
+            data.system.effects.heal.formula = null;
             return this.item.update(data);
         }
-        if (name === "data.properties.buff" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.effects.buff.formula = null;
+        if (name === "system.properties.buff" && !checked) {
+            let data = duplicate(this.item);
+            data.system.effects.buff.formula = null;
             return this.item.update(data);
         }
-        if (name === "data.properties.temporary" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.properties.duration.formula = null;
-            data.data.properties.duration.units = "";
+        if (name === "system.properties.temporary" && !checked) {
+            let data = duplicate(this.item);
+            data.system.properties.duration.formula = null;
+            data.system.properties.duration.units = "";
             return this.item.update(data);
         }
-        if (name === "data.properties.spell" && !checked) {
-            let data = duplicate(this.item.data);
-            data.data.properties.activable = false;
+        if (name === "system.properties.spell" && !checked) {
+            let data = duplicate(this.item);
+            data.system.properties.activable = false;
             return this.item.update(data);
         }
     }

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -2,7 +2,7 @@
  * Extend the basic ItemSheet with some very simple modifications
  * @extends {ItemSheet}
  */
-import { CocHealingRoll } from "../controllers/healing-roll.js"; 
+import { CocHealingRoll } from "../controllers/healing-roll.js";
 import { COC } from "../system/config.js";
 export class CoCItem extends Item {
 
@@ -10,7 +10,7 @@ export class CoCItem extends Item {
     /*  Constructor                                 */
     /* -------------------------------------------- */
     /* Définition de l'image par défaut             */
-    /* -------------------------------------------- */   
+    /* -------------------------------------------- */
     constructor(...args) {
         let data = args[0];
         if (!data.img && COC.itemIcons[data.type]) data.img = COC.itemIcons[data.type];
@@ -70,7 +70,7 @@ export class CoCItem extends Item {
             const r = new CocHealingRoll(itemData.name, heal.formula, false);
             r.roll(actor);
         }
-    }    
+    }
 
     modifyQuantity(increment, isDecrease) {
         if(this.data.data.properties.stackable){

--- a/module/items/item.js
+++ b/module/items/item.js
@@ -21,8 +21,8 @@ export class CoCItem extends Item {
     /** @override */
     prepareData() {
         super.prepareData();
-        const itemData = this.data;
-        const actorData = (this.actor) ? this.actor.data : null;
+        const itemData = this;
+        const actorData = (this.actor) ? this.actor : null;
         switch (itemData.type) {
             case "item" :
                 this._prepareArmorData(itemData, actorData);
@@ -32,8 +32,8 @@ export class CoCItem extends Item {
             case "trait" :
             case "capacity" :
             case "profile" :
-                if(!itemData.data.setting) itemData.data.setting = "base";
-                itemData.data.key = itemData.data.setting + "-" + itemData.name.slugify({strict: true});
+                if(!itemData.system.setting) itemData.system.setting = "base";
+                itemData.system.key = itemData.system.setting + "-" + itemData.name.slugify({strict: true});
                 break;
             default :
                 break;
@@ -41,48 +41,48 @@ export class CoCItem extends Item {
     }
 
     _prepareArmorData(itemData, actorData) {
-        itemData.data.def = parseInt(itemData.data.defBase, 10) + parseInt(itemData.data.defBonus, 10);
+        itemData.system.def = parseInt(itemData.system.defBase, 10) + parseInt(itemData.system.defBonus, 10);
     }
 
     _prepareWeaponData(itemData, actorData) {
-        itemData.data.skillBonus = (itemData.data.skillBonus) ? itemData.data.skillBonus : 0;
-        itemData.data.dmgBonus = (itemData.data.dmgBonus) ? itemData.data.dmgBonus : 0;
+        itemData.system.skillBonus = (itemData.system.skillBonus) ? itemData.system.skillBonus : 0;
+        itemData.system.dmgBonus = (itemData.system.dmgBonus) ? itemData.system.dmgBonus : 0;
 
         if (actorData) {
             // Compute skill mod
-            const skillMod = eval("actorData.data." + itemData.data.skill.split("@")[1]);
-            itemData.data.mod = parseInt(skillMod) + parseInt(itemData.data.skillBonus);
+            const skillMod = eval("actorData.system." + itemData.system.skill.split("@")[1]);
+            itemData.system.mod = parseInt(skillMod) + parseInt(itemData.system.skillBonus);
             // Compute damage mod
-            const dmgStat = eval("actorData.data." + itemData.data.dmgStat.split("@")[1]);
-            const dmgBonus = (dmgStat) ? parseInt(dmgStat) + parseInt(itemData.data.dmgBonus) : parseInt(itemData.data.dmgBonus);
-            const dmgBase = itemData.data.dmgBase;
-            if (dmgBonus < 0) itemData.data.dmg = dmgBase + " - " + parseInt(-dmgBonus);
-            else if (dmgBonus === 0) itemData.data.dmg = dmgBase;
-            else itemData.data.dmg = dmgBase + " + " + dmgBonus;
+            const dmgStat = eval("actorData.system." + itemData.system.dmgStat.split("@")[1]);
+            const dmgBonus = (dmgStat) ? parseInt(dmgStat) + parseInt(itemData.system.dmgBonus) : parseInt(itemData.system.dmgBonus);
+            const dmgBase = itemData.system.dmgBase;
+            if (dmgBonus < 0) itemData.system.dmg = dmgBase + " - " + parseInt(-dmgBonus);
+            else if (dmgBonus === 0) itemData.system.dmg = dmgBase;
+            else itemData.system.dmg = dmgBase + " + " + dmgBonus;
         }
     }
 
     applyEffects(actor){
-        const itemData = this.data;
+        const itemData = this;
 
-        if(itemData.data.properties.heal){
-            const heal = itemData.data.effects.heal;
+        if(itemData.system.properties.heal){
+            const heal = itemData.system.effects.heal;
             const r = new CocHealingRoll(itemData.name, heal.formula, false);
             r.roll(actor);
         }
     }
 
     modifyQuantity(increment, isDecrease) {
-        if(this.data.data.properties.stackable){
-            let itemData = duplicate(this.data);
-            const qty = itemData.data.qty;
-            if(isDecrease) itemData.data.qty = qty - increment;
-            else itemData.data.qty = qty + increment;
-            if(itemData.data.qty < 0) itemData.data.qty = 0;
-            if(itemData.data.stacksize && itemData.data.qty > itemData.data.stacksize) itemData.data.qty = itemData.data.stacksize;
-            if(itemData.data.price){
-                const qty = (itemData.data.qty) ? itemData.data.qty : 1;
-                itemData.data.value = qty * itemData.data.price;
+        if(this.system.properties.stackable){
+            let itemData = duplicate(this);
+            const qty = itemData.system.qty;
+            if(isDecrease) itemData.system.qty = qty - increment;
+            else itemData.system.qty = qty + increment;
+            if(itemData.system.qty < 0) itemData.system.qty = 0;
+            if(itemData.system.stacksize && itemData.system.qty > itemData.system.stacksize) itemData.system.qty = itemData.system.stacksize;
+            if(itemData.system.price){
+                const qty = (itemData.system.qty) ? itemData.system.qty : 1;
+                itemData.system.value = qty * itemData.system.price;
             }
             return this.update(itemData);
         }

--- a/module/system/config.js
+++ b/module/system/config.js
@@ -89,28 +89,28 @@ COC.traits = [];
 
 // Mise en cache des données de profil
 COC.getProfiles = async function () {
-    let profiles = await game.packs.get("coc.profiles").getContent().then(index => index.map(entity => entity.data));
+    let profiles = await game.packs.get("coc.profiles").getContent().then(index => index.map(entity => entity));
     COC.profiles = profiles;
     if (COC.debug) console.debug("COC | Profiles loaded");
 };
 
 // Mise en cache des données de voies
 COC.getPaths = async function () {
-    let paths = await game.packs.get("coc.paths").getContent().then(index => index.map(entity => entity.data));
+    let paths = await game.packs.get("coc.paths").getContent().then(index => index.map(entity => entity));
     COC.paths = paths;
     if (COC.debug) console.debug("COC | Paths loaded");
 };
 
 // Mise en cache des données de capacités
 COC.getCapacities = async function () {
-    let capacities = await game.packs.get("coc.capacities").getContent().then(index => index.map(entity => entity.data));
+    let capacities = await game.packs.get("coc.capacities").getContent().then(index => index.map(entity => entity));
     COC.capacities = capacities;
     if (COC.debug) console.debug("COC | Capacities loaded");
 };
 
 // Mise en cache des données de capacités
 COC.getTraits = async function () {
-    let traits = await game.packs.get("coc.traits").getContent().then(index => index.map(entity => entity.data));
+    let traits = await game.packs.get("coc.traits").getContent().then(index => index.map(entity => entity));
     COC.traits = traits;
     if (COC.debug) console.debug("COC | Traits loaded");
 };

--- a/module/system/config.js
+++ b/module/system/config.js
@@ -8,13 +8,13 @@ System.templatesPath = System.rootPath + "/templates";
 System.debugMode = true;
 
 System.ASCII = `
-   ******    *******     ****** 
+   ******    *******     ******
   **////**  **/////**   **////**
- **    //  **     //** **    // 
-/**       /**      /**/**       
-/**       /**      /**/**       
+ **    //  **     //** **    //
+/**       /**      /**/**
+/**       /**      /**/**
 //**    **//**     ** //**    **
- //******  //*******   //****** 
+ //******  //*******   //******
   //////    ///////     ////// `;
 
 export const COC = {};
@@ -137,7 +137,7 @@ COC.itemCategories = {
     "consumable": "COC.category.consumable",
     "container": "COC.category.container",
     "mount": "COC.category.mount",
-    "vehicle": "COC.category.vehicle",    
+    "vehicle": "COC.category.vehicle",
     "trapping": "COC.category.trapping",
     "other": "COC.category.other"
 }

--- a/module/system/helpers.js
+++ b/module/system/helpers.js
@@ -186,11 +186,11 @@ export const registerHandlebarsHelpers = function () {
     });
 
     Handlebars.registerHelper('isNotLimited', function(options){
-        return !options?.limited;    
+        return !options?.limited;
     });
 
     Handlebars.registerHelper('isNotLimitedEncounter', function(options){
-        return !(options?.limited && options?.actor?.type === "encounter");    
+        return !(options?.limited && options?.actor?.type === "encounter");
     });
 
     Handlebars.registerHelper('getFpLabel', function(){

--- a/module/system/helpers.js
+++ b/module/system/helpers.js
@@ -9,18 +9,18 @@ export const registerHandlebarsHelpers = function () {
     Handlebars.registerHelper('getInventory', function (items) {
         let inventory = items.filter(item => item.type === "item");
         inventory.sort(function (a, b) {
-            const aKey = a.data.subtype + "-" + a.name.slugify({strict: true});
-            const bKey = b.data.subtype + "-" + b.name.slugify({strict: true});
+            const aKey = a.system.subtype + "-" + a.name.slugify({strict: true});
+            const bKey = b.system.subtype + "-" + b.name.slugify({strict: true});
             return (aKey > bKey) ? 1 : -1
         });
         return inventory;
     });
 
     Handlebars.registerHelper('getWorn', function (items) {
-        let worn = items.filter(item => item.type === "item" && item.data.worn);
+        let worn = items.filter(item => item.type === "item" && item.system.worn);
         worn.sort(function (a, b) {
-            const aKey = a.data.subtype + "-" + a.name.slugify({strict: true});
-            const bKey = b.data.subtype + "-" + b.name.slugify({strict: true});
+            const aKey = a.system.subtype + "-" + a.name.slugify({strict: true});
+            const bKey = b.system.subtype + "-" + b.name.slugify({strict: true});
             return (aKey > bKey) ? 1 : -1
         });
         return worn;
@@ -37,8 +37,8 @@ export const registerHandlebarsHelpers = function () {
     Handlebars.registerHelper('getCapacities', function (items) {
         let caps = items.filter(item => item.type === "capacity");
         caps.sort(function (a, b) {
-            const aKey = a.data.path + "-" + a.data.rank;
-            const bKey = b.data.path + "-" + b.data.rank;
+            const aKey = a.system.path + "-" + a.system.rank;
+            const bKey = b.system.path + "-" + b.system.rank;
             return (aKey > bKey) ? 1 : -1
         });
         return caps;
@@ -59,7 +59,7 @@ export const registerHandlebarsHelpers = function () {
     });
 
     Handlebars.registerHelper('getPath', function (items, pathKey) {
-        return items.filter(item => item.type === "path").find(p => p.data.key === pathKey);
+        return items.filter(item => item.type === "path").find(p => p.system.key === pathKey);
     });
 
     Handlebars.registerHelper('isNull', function (val) {
@@ -143,11 +143,11 @@ export const registerHandlebarsHelpers = function () {
     });
 
     Handlebars.registerHelper('findPath', function (key) {
-        return Traversal.getAllPathsData().find(p => p.data.key === key);
+        return Traversal.getAllPathsData().find(p => p.system.key === key);
     });
 
     Handlebars.registerHelper('findCapacity', function (key) {
-        return Traversal.getAllCapacitiesData().find(c => c.data.key === key);
+        return Traversal.getAllCapacitiesData().find(c => c.system.key === key);
     });
 
     // If you need to add Handlebars helpers, here are a few useful examples:
@@ -174,7 +174,7 @@ export const registerHandlebarsHelpers = function () {
     });
 
     Handlebars.registerHelper('includesKey', function (items, type, key) {
-        return items.filter(i => i.type === type).map(i => i.data.key).includes(key);
+        return items.filter(i => i.type === type).map(i => i.system.key).includes(key);
     });
 
     Handlebars.registerHelper('isCategoryIn', function () {

--- a/module/system/hooks.js
+++ b/module/system/hooks.js
@@ -1,5 +1,6 @@
 import {CharacterGeneration} from "./chargen.js";
 import {Hitpoints} from "../controllers/hitpoints.js";
+import {CoCActor} from "../actors/actor.js"
 
 export default function registerHooks() {
 
@@ -74,13 +75,14 @@ export default function registerHooks() {
          Hooks.on("hotbarDrop", async (bar, data, slot) => {
             // Create item macro if rollable item - weapon, spell, prayer, trait, or skill
             if (data.type == "Item") {
-                let item = data.data;
+                let item = await fromUuid(data.uuid);
 
                 if (item === undefined) return;
+                if (item.type === "encounterWeapon") return;
 
                 let command = `let onlyDamage = false;\nlet customLabel = "";\nlet skillDescription = "";\nlet dmgDescription = "";\n\nif (event) {\n  if (event.shiftKey) onlyDamage = true;\n}\n\ngame.coc.macros.rollItemMacro("${item._id}", "${item.name}", "${item.type}", 0, 0, 0, onlyDamage, customLabel, skillDescription, dmgDescription);`;
 
-                let macro = game.macros.contents.find(m => (m.name === item.name) && (m.data.command === command));
+                let macro = game.macros.contents.find(m => (m.name === item.name) && (m.command === command));
                 if (!macro) {
                     macro = await Macro.create({
                         name: item.name,
@@ -94,14 +96,14 @@ export default function registerHooks() {
             }
             // Create a macro to open the actor sheet of the actor dropped on the hotbar
             else if (data.type == "Actor") {
-                let actor = game.actors.get(data.id);
-                let command = `game.actors.get("${data.id}").sheet.render(true)`
-                let macro = game.macros.contents.find(m => (m.name === actor.name) && (m.data.command === command));
+                let actor = await fromUuid(data.uuid);
+                let command = `game.actors.get("${actor.id}").sheet.render(true)`
+                let macro = game.macros.contents.find(m => (m.name === actor.name) && (m.command === command));
                 if (!macro) {
                     macro = await Macro.create({
-                        name: actor.data.name,
+                        name: actor.name,
                         type: "script",
-                        img: actor.data.img,
+                        img: actor.img,
                         command: command
                     }, {displaySheet: false});
                     game.user.assignHotbarMacro(macro, slot);
@@ -109,14 +111,14 @@ export default function registerHooks() {
             }
             // Create a macro to open the journal sheet of the journal dropped on the hotbar
             else if (data.type == "JournalEntry") {
-                let journal = game.journal.get(data.id);
-                let command = `game.journal.get("${data.id}").sheet.render(true)`
-                let macro = game.macros.contents.find(m => (m.name === journal.name) && (m.data.command === command));
+                let journal = await fromUuid(data.uuid);
+                let command = `game.journal.get("${journal.id}").sheet.render(true)`
+                let macro = game.macros.contents.find(m => (m.name === journal.name) && (m.command === command));
                 if (!macro) {
                     macro = await Macro.create({
-                        name: journal.data.name,
+                        name: journal.name,
                         type: "script",
-                        img: (journal.data.img) ? journal.data.img : "icons/svg/book.svg",
+                        img: (journal.img) ? journal.img : "icons/svg/book.svg",
                         command: command
                     }, {displaySheet: false});
                     game.user.assignHotbarMacro(macro, slot);
@@ -198,7 +200,7 @@ export default function registerHooks() {
         // Si l'effet ne s'applique pas à un actor, on quitte en laissant l'effet se créer normalement
         if (!activeEffect.parent instanceof CoCActor) return;
 
-        let origin = activeEffect.data.origin;
+        let origin = activeEffect.origin;
         // Si l'effet ne provient pas d'un item, on quitte en laissant l'effet se créer normalement
         if (!/Item\.[^.]+$/.test(origin)) return;
 
@@ -215,13 +217,13 @@ export default function registerHooks() {
         else return true;
 
         // Si l'item parent n'est pas équipable, on quitte en laissant l'effet se créer normalement
-        let itemData = item.data;
-        if (!itemData.data.properties.equipable) return;
+        let itemData = item;
+        if (!itemData.system.properties?.equipable) return;
 
         // Si l'effet est déjà à jour, on quitte
-        if (activeEffect.data.disabled === !itemData.worn) return;
+        if (activeEffect.disabled === !itemData.system.worn) return;
 
         // On met à jour l'effet en fonction du fait que l'item est équipé ou non
-        activeEffect.update({disabled: !itemData.worn});
+        activeEffect.update({disabled: !itemData.system.worn});
     });
 }

--- a/module/system/hooks.js
+++ b/module/system/hooks.js
@@ -63,7 +63,7 @@ export default function registerHooks() {
             }
         );
     });
-    
+
         /**
      * Create a macro when dropping an entity on the hotbar
      * Item      - open roll dialog for item
@@ -75,11 +75,11 @@ export default function registerHooks() {
             // Create item macro if rollable item - weapon, spell, prayer, trait, or skill
             if (data.type == "Item") {
                 let item = data.data;
-                
+
                 if (item === undefined) return;
 
                 let command = `let onlyDamage = false;\nlet customLabel = "";\nlet skillDescription = "";\nlet dmgDescription = "";\n\nif (event) {\n  if (event.shiftKey) onlyDamage = true;\n}\n\ngame.coc.macros.rollItemMacro("${item._id}", "${item.name}", "${item.type}", 0, 0, 0, onlyDamage, customLabel, skillDescription, dmgDescription);`;
-    
+
                 let macro = game.macros.contents.find(m => (m.name === item.name) && (m.data.command === command));
                 if (!macro) {
                     macro = await Macro.create({
@@ -88,9 +88,9 @@ export default function registerHooks() {
                         img: item.img,
                         command : command
                     }, {displaySheet: false});
-                    game.user.assignHotbarMacro(macro, slot);                    
+                    game.user.assignHotbarMacro(macro, slot);
                 }
-                
+
             }
             // Create a macro to open the actor sheet of the actor dropped on the hotbar
             else if (data.type == "Actor") {
@@ -124,15 +124,15 @@ export default function registerHooks() {
             }
             return false;
         });
-    
-    
+
+
         /**
          * Intercepte les commandes de chat
          * /stat - Jet de caractéristique
          * /skill stat - Jet de caractéristique
          * /stats - Génère les caractéristiques d'un personnage
          */
-    
+
         Hooks.on("chatMessage", (html, content, msg) => {
             let regExp;
             regExp = /(\S+)/g;
@@ -140,9 +140,9 @@ export default function registerHooks() {
             let command = (commands.length>0 && commands[0].split("/").length > 0) ? commands[0].split("/")[1].trim() : null;
             let arg1 = (commands.length > 1) ? commands[1].trim() : null;
             const actor = game.coc.macros.getSpeakersActor();
-    
+
             const validCommands = ["for", "str", "dex", "con", "int", "sag", "wis", "cha", "atc", "melee", "atd", "ranged", "atm", "magic"];
-    
+
             if(command && validCommands.includes(command)) {
                 game.coc.macros.rollStatMacro(actor, command, 0, 0, null);
                 return false;
@@ -160,15 +160,15 @@ export default function registerHooks() {
                 return false;
             }
         });
-    
+
         Hooks.on("renderChatMessage", (message, html, data) => {
             // Affiche ou non les boutons d'application des dommages
             if (game.settings.get("coc", "displayChatDamageButtonsToAll")) {
-                html.find(".apply-dmg").click(ev => Hitpoints.onClickChatMessageApplyButton(ev, html, data));    
+                html.find(".apply-dmg").click(ev => Hitpoints.onClickChatMessageApplyButton(ev, html, data));
             }
             else {
                 if (game.user.isGM){
-                    html.find(".apply-dmg").click(ev => Hitpoints.onClickChatMessageApplyButton(ev, html, data));    
+                    html.find(".apply-dmg").click(ev => Hitpoints.onClickChatMessageApplyButton(ev, html, data));
                 }
                 else {
                     html.find(".apply-dmg").each((i, btn) => {
@@ -177,8 +177,8 @@ export default function registerHooks() {
                     html.find(".dr-checkbox").each((i, btn) => {
                         btn.style.display = "none"
                     });
-                }        
-            }        
+                }
+            }
             // Affiche ou non la difficulté
             const displayDifficulty = game.settings.get("coc", "displayDifficulty");
             if (displayDifficulty === "none" || (displayDifficulty === "gm" && !game.user.isGM)) {
@@ -217,11 +217,11 @@ export default function registerHooks() {
         // Si l'item parent n'est pas équipable, on quitte en laissant l'effet se créer normalement
         let itemData = item.data;
         if (!itemData.data.properties.equipable) return;
-        
+
         // Si l'effet est déjà à jour, on quitte
         if (activeEffect.data.disabled === !itemData.worn) return;
 
         // On met à jour l'effet en fonction du fait que l'item est équipé ou non
         activeEffect.update({disabled: !itemData.worn});
-    });        
+    });
 }

--- a/module/system/macros.js
+++ b/module/system/macros.js
@@ -7,8 +7,8 @@ export class Macros {
     /**
      * @name getSpeakersActor
      * @description
-     * 
-     * @returns 
+     *
+     * @returns
      */
     static getSpeakersActor = function(){
         // Vérifie qu'un seul token est sélectionné
@@ -17,7 +17,7 @@ export class Macros {
             ui.notifications.warn(game.i18n.localize('COC.notification.MacroMultipleTokensSelected'));
             return null;
         }
-        
+
         const speaker = ChatMessage.getSpeaker();
         let actor;
         // Si un token est sélectionné, le prendre comme acteur cible
@@ -30,18 +30,18 @@ export class Macros {
     /**
      * @anme rollStatMacro
      * @description
-     * 
-     * @param {*} actor 
-     * @param {*} stat 
-     * @param {*} bonus 
-     * @param {*} malus 
-     * @param {*} onEnter 
-     * @param {*} label 
-     * @param {*} description 
-     * @param {*} dialog 
-     * @param {*} dice 
-     * @param {*} difficulty 
-     * @returns 
+     *
+     * @param {*} actor
+     * @param {*} stat
+     * @param {*} bonus
+     * @param {*} malus
+     * @param {*} onEnter
+     * @param {*} label
+     * @param {*} description
+     * @param {*} dialog
+     * @param {*} dice
+     * @param {*} difficulty
+     * @returns
      */
      static rollStatMacro = async function (actor, stat, bonus = 0, malus = 0, onEnter = "submit", label, description, dialog=true, dice="1d20", difficulty) {
         // Plusieurs tokens sélectionnés
@@ -66,7 +66,7 @@ export class Macros {
             case "atm" :
             case "magic" : statObj = eval(`actor.data.data.attacks.magic`); break;
             default :
-                ui.notifications.error(game.i18n.localize("COC.notification.MacroUnknownStat")); 
+                ui.notifications.error(game.i18n.localize("COC.notification.MacroUnknownStat"));
                 break;
         }
         let mod = statObj.mod;
@@ -88,25 +88,25 @@ export class Macros {
             CoCRoll.skillRollDialog(actor, label && label.length > 0 ? label : game.i18n.localize(statObj.label), mod, bonus, malus, 20, statObj.superior, onEnter, description);
         }
         else{
-            return new SkillRoll(label && label.length > 0 ? label : game.i18n.localize(statObj.label), dice, "+" + +mod, bonus, malus, difficulty, "20", description).roll();        
+            return new SkillRoll(label && label.length > 0 ? label : game.i18n.localize(statObj.label), dice, "+" + +mod, bonus, malus, difficulty, "20", description).roll();
         }
     };
 
     /**
      * @name rollItemMacro
      * @description
-     * 
-     * @param {*} itemId 
-     * @param {*} itemName 
-     * @param {*} itemType 
-     * @param {*} bonus 
-     * @param {*} malus 
-     * @param {*} dmgBonus 
-     * @param {*} dmgOnly 
-     * @param {*} customLabel 
-     * @param {*} skillDescr 
-     * @param {*} dmgDescr 
-     * @returns 
+     *
+     * @param {*} itemId
+     * @param {*} itemName
+     * @param {*} itemType
+     * @param {*} bonus
+     * @param {*} malus
+     * @param {*} dmgBonus
+     * @param {*} dmgOnly
+     * @param {*} customLabel
+     * @param {*} skillDescr
+     * @param {*} dmgDescr
+     * @returns
      */
      static rollItemMacro = async function (itemId, itemName, itemType, bonus = 0, malus = 0, dmgBonus=0, dmgOnly=false, customLabel, skillDescr, dmgDescr, dialog=true) {
         const actor = this.getSpeakersActor();
@@ -117,7 +117,7 @@ export class Macros {
 
         const item = actor.items.get(itemId);
         if (!item) return ui.notifications.warn(game.i18n.format('COC.notification.MacroItemMissing', {item:itemName}));
-        
+
         const itemData = item.data;
 
         if(itemData.data.properties.weapon || itemData.data.properties.heal){
@@ -125,37 +125,37 @@ export class Macros {
                 if (itemData.data.properties.equipable && !itemData.data.worn) {
                     return ui.notifications.warn(game.i18n.format('COC.notification.MacroItemUnequiped', {item: itemName}));
                 }
-                const label =  customLabel && customLabel.length > 0 ? customLabel : itemData.name;                
-                const critrange = itemData.data.critrange;              
+                const label =  customLabel && customLabel.length > 0 ? customLabel : itemData.name;
+                const critrange = itemData.data.critrange;
 
                 // Compute MOD
                 const itemModStat = itemData.data.skill.split("@")[1];
                 const itemModBonus = parseInt(itemData.data.skillBonus);
-                
+
                 let mod = actor.computeWeaponMod(itemModStat, itemModBonus);
 
                 // Compute DM
-                const itemDmgBase = itemData.data.dmgBase;                        
+                const itemDmgBase = itemData.data.dmgBase;
                 const itemDmgStat = itemData.data.dmgStat.split("@")[1];
                 const itemDmgBonus = parseInt(itemData.data.dmgBonus);
 
                 let dmg = actor.computeDm(itemDmgBase, itemDmgStat, itemDmgBonus)
-                
+
                 if (dialog){
                     if (dmgOnly) CoCRoll.rollDamageDialog(actor, label, dmg, 0, false, "submit", dmgDescr);
                     else CoCRoll.rollWeaponDialog(actor, label, mod, bonus, malus, critrange, dmg, dmgBonus, "submit", skillDescr, dmgDescr);
                 }
                 else {
                     let formula = dmgBonus ? dmg +  "+" + dmgBonus : dmg;
-                    if (dmgOnly) new DamageRoll(label, formula, false, dmgDescr).roll(); 
-                    else {        
+                    if (dmgOnly) new DamageRoll(label, formula, false, dmgDescr).roll();
+                    else {
                         let skillRoll = await new SkillRoll(label, "1d20", "+" + +mod, bonus, malus, null, critrange, skillDescr).roll();
 
                         let result = skillRoll.dice[0].results[0].result;
                         let critical = ((result >= critrange.split("-")[0]) || result == 20);
-                        
-                        new DamageRoll(label, formula, critical, dmgDescr).roll();                            
-                    }                    
+
+                        new DamageRoll(label, formula, critical, dmgDescr).roll();
+                    }
                 }
             }
             if (itemData.data.properties.heal){
@@ -185,19 +185,19 @@ export class Macros {
 
         let crit = parseInt(critRange);
         crit = !isNaN(crit) ? crit : 20;
-        CoCRoll.skillRollDialog(actor, label, mod, bonus, malus, crit, isSuperior, "submit", description);  
+        CoCRoll.skillRollDialog(actor, label, mod, bonus, malus, crit, isSuperior, "submit", description);
     }
 
     static rollDamageMacro = async function(label, dmgFormula, dmgBonus, isCritical, dmgDescr){
         const actor = this.getSpeakersActor();
-        
+
         // Several tokens selected
         if (actor === null) return;
         // Aucun acteur cible
         if (actor === undefined) return ui.notifications.error(game.i18n.localize("COC.notification.MacroNoActorAvailable"));
 
         CoCRoll.rollDamageDialog(actor, label, dmgFormula, dmgBonus, isCritical, "submit", dmgDescr);
-          
+
     }
 
 

--- a/module/system/macros.js
+++ b/module/system/macros.js
@@ -52,19 +52,19 @@ export class Macros {
         let statObj;
         switch(stat){
             case "for" :
-            case "str" : statObj = eval(`actor.data.data.stats.str`); break;
-            case "dex" : statObj = eval(`actor.data.data.stats.dex`); break;
-            case "con" : statObj = eval(`actor.data.data.stats.con`); break;
-            case "int" : statObj = eval(`actor.data.data.stats.int`); break;
+            case "str" : statObj = eval(`actor.system.stats.str`); break;
+            case "dex" : statObj = eval(`actor.system.stats.dex`); break;
+            case "con" : statObj = eval(`actor.system.stats.con`); break;
+            case "int" : statObj = eval(`actor.system.stats.int`); break;
             case "sag" :
-            case "wis" : statObj = eval(`actor.data.data.stats.wis`); break;
-            case "cha" : statObj = eval(`actor.data.data.stats.cha`); break;
+            case "wis" : statObj = eval(`actor.system.stats.wis`); break;
+            case "cha" : statObj = eval(`actor.system.stats.cha`); break;
             case "atc" :
-            case "melee" : statObj = eval(`actor.data.data.attacks.melee`); break;
+            case "melee" : statObj = eval(`actor.system.attacks.melee`); break;
             case "atd" :
-            case "ranged" : statObj = eval(`actor.data.data.attacks.ranged`); break;
+            case "ranged" : statObj = eval(`actor.system.attacks.ranged`); break;
             case "atm" :
-            case "magic" : statObj = eval(`actor.data.data.attacks.magic`); break;
+            case "magic" : statObj = eval(`actor.system.attacks.magic`); break;
             default :
                 ui.notifications.error(game.i18n.localize("COC.notification.MacroUnknownStat"));
                 break;
@@ -118,26 +118,26 @@ export class Macros {
         const item = actor.items.get(itemId);
         if (!item) return ui.notifications.warn(game.i18n.format('COC.notification.MacroItemMissing', {item:itemName}));
 
-        const itemData = item.data;
+        const itemData = item;
 
-        if(itemData.data.properties.weapon || itemData.data.properties.heal){
-            if (itemData.data.properties.weapon){
-                if (itemData.data.properties.equipable && !itemData.data.worn) {
+        if(itemData.system.properties.weapon || itemData.system.properties.heal){
+            if (itemData.system.properties.weapon){
+                if (itemData.system.properties.equipable && !itemData.system.worn) {
                     return ui.notifications.warn(game.i18n.format('COC.notification.MacroItemUnequiped', {item: itemName}));
                 }
                 const label =  customLabel && customLabel.length > 0 ? customLabel : itemData.name;
-                const critrange = itemData.data.critrange;
+                const critrange = itemData.system.critrange;
 
                 // Compute MOD
-                const itemModStat = itemData.data.skill.split("@")[1];
-                const itemModBonus = parseInt(itemData.data.skillBonus);
+                const itemModStat = itemData.system.skill.split("@")[1];
+                const itemModBonus = parseInt(itemData.system.skillBonus);
 
                 let mod = actor.computeWeaponMod(itemModStat, itemModBonus);
 
                 // Compute DM
-                const itemDmgBase = itemData.data.dmgBase;
-                const itemDmgStat = itemData.data.dmgStat.split("@")[1];
-                const itemDmgBonus = parseInt(itemData.data.dmgBonus);
+                const itemDmgBase = itemData.system.dmgBase;
+                const itemDmgStat = itemData.system.dmgStat.split("@")[1];
+                const itemDmgBonus = parseInt(itemData.system.dmgBonus);
 
                 let dmg = actor.computeDm(itemDmgBase, itemDmgStat, itemDmgBonus)
 
@@ -158,8 +158,8 @@ export class Macros {
                     }
                 }
             }
-            if (itemData.data.properties.heal){
-                new CocHealingRoll(itemData.name, itemData.data.effects.heal.formula, false).roll(actor);
+            if (itemData.system.properties.heal){
+                new CocHealingRoll(itemData.name, itemData.system.effects.heal.formula, false).roll(actor);
             }
         }
         else { return item.sheet.render(true); }

--- a/module/system/settings.js
+++ b/module/system/settings.js
@@ -89,7 +89,7 @@ export const registerSystemSettings = function() {
         default: false,
         type: Boolean
     });
-    
+
     game.settings.register("coc", "moveItem", {
         name: "Mode de déplacement des items",
         hint: "Comportement du drag & drop d'un item sur une fiche de personnage (Maintenir MAJ lors du drop pour inverser)",
@@ -100,8 +100,8 @@ export const registerSystemSettings = function() {
             "1" : "SETTINGS.moveItem.move"
         },
         default: "0",
-        config: true                
-    });   
+        config: true
+    });
 
     game.settings.register("coc", "lockItems",{
         name: "SETTINGS.lockItems.name",
@@ -109,16 +109,16 @@ export const registerSystemSettings = function() {
         scope: "world",
         config: true,
         default: false,
-        type: Boolean       
-    });  
-    
+        type: Boolean
+    });
+
     game.settings.register("coc", "explosiveDice",{
         name: "SETTINGS.explosiveDice.name",
         hint: "SETTINGS.explosiveDice.hint",
         scope: "world",
         config: true,
         default: true,
-        type: Boolean       
+        type: Boolean
     });
 
     game.settings.register("coc", "checkFreeHandsBeforeEquip", {
@@ -147,7 +147,7 @@ export const registerSystemSettings = function() {
             "all" : "SETTINGS.checkArmorSlotAvailability.all",
             "gm" : "SETTINGS.checkArmorSlotAvailability.gm"
         }
-    }); 
+    });
 
     game.settings.register("coc", "settingCyberpunk",{
         name: "SETTINGS.settingCyberpunk.name",
@@ -156,7 +156,7 @@ export const registerSystemSettings = function() {
         config: true,
         default: false,
         type: Boolean,
-        onChange: reload       
+        onChange: reload
     });
 
 };

--- a/module/utils/compendia.js
+++ b/module/utils/compendia.js
@@ -25,7 +25,7 @@ export class Compendia {
         let promises = game.packs.map(comp => {
             return comp.getIndex().then(index => {
                 return index.map(entry => {
-                    entry.sourceId = "Compendium."+comp.metadata.package + "." + comp.metadata.name + "." + entry._id;
+                    entry.sourceId = "Compendium."+comp.metadata.packageName + "." + comp.metadata.name + "." + entry._id;
                     return entry;
                 });
             });

--- a/module/utils/compendia.js
+++ b/module/utils/compendia.js
@@ -2,9 +2,9 @@ export class Compendia {
 
     /**
      * @todo : Renommer la méthode getContent en getDocuments
-     * 
-     * @param {*} filters 
-     * @returns 
+     *
+     * @param {*} filters
+     * @returns
      */
     static getContent(filters = []) {
         let promises = game.packs.map(comp => {

--- a/module/utils/data.js
+++ b/module/utils/data.js
@@ -52,7 +52,7 @@ export class DataLoader {
         let pack = this.findPack(packName);
 
         // Get entity type to populate the proper collection
-        const entity = pack.metadata.entity;
+        const entity = pack.metadata.type;
 
         // Unlock the pack
         pack.locked = false;

--- a/module/utils/string-utils.js
+++ b/module/utils/string-utils.js
@@ -7,7 +7,7 @@ export class StringUtils {
     static toKey (str) {
         return StringUtils.normalize(str).split(/[\s;:,\']+/).join('-');
     }
-    
+
     static async sha256(message) {
 
         // encode as UTF-8

--- a/module/utils/traversal.js
+++ b/module/utils/traversal.js
@@ -20,26 +20,26 @@ export class Traversal {
         return Compendia.getIndex().then(index =>{
             let items = game.items.map(entity => {
                 return {
-                    _id : entity.data._id,
-                    name : entity.data.name,
-                    img : entity.data.img,
-                    sourceId : "Item."+entity.data._id
+                    _id : entity._id,
+                    name : entity.name,
+                    img : entity.img,
+                    sourceId : "Item."+entity._id
                 }
             });
             let actors = game.actors.map(entity => {
                 return {
-                    _id : entity.data._id,
-                    name : entity.data.name,
-                    img : entity.data.img,
-                    sourceId : "Actor."+entity.data._id
+                    _id : entity._id,
+                    name : entity.name,
+                    img : entity.img,
+                    sourceId : "Actor."+entity._id
                 }
             });
             let journal = game.journal.map(entity => {
                 return {
-                    _id : entity.data._id,
-                    name : entity.data.name,
-                    img : entity.data.img,
-                    sourceId : "JournalEntry."+entity.data._id
+                    _id : entity._id,
+                    name : entity.name,
+                    img : entity.img,
+                    sourceId : "JournalEntry."+entity._id
                 }
             });
             return items.concat(actors, journal, Object.values(index)).reduce(function (map, obj) {
@@ -52,8 +52,8 @@ export class Traversal {
     static mapItemsOfType(types) {
         return Compendia.getContent(types).then(content =>{
             return game.items.filter(item => types.includes(item.type))
-                .map(entity => entity.data)
-                .concat(Object.values(content).map(entity => entity.data))
+                .map(entity => entity)
+                .concat(Object.values(content).map(entity => entity))
                 .reduce(function (map, obj) {
                     map[obj._id] = obj;
                     return map;
@@ -82,14 +82,14 @@ export class Traversal {
         let ingame = [];
         switch(type){
             case "path" :
-                // compendium = await game.packs.get("coc.paths").getContent().then(index => index.map(entity => entity.data));
+                // compendium = await game.packs.get("coc.paths").getContent().then(index => index.map(entity => entity));
                 compendium = COC.paths;
-                ingame = game.items.filter(item => item.type === "path").map(entity => entity.data);
+                ingame = game.items.filter(item => item.type === "path").map(entity => entity);
                 break;
             case "capacity" :
-                // compendium = await game.packs.get("coc.capacities").getContent().then(index => index.map(entity => entity.data));
+                // compendium = await game.packs.get("coc.capacities").getContent().then(index => index.map(entity => entity));
                 compendium = COC.capacities;
-                ingame = game.items.filter(item => item.type === "capacity").map(entity => entity.data);
+                ingame = game.items.filter(item => item.type === "capacity").map(entity => entity);
                 break;
         }
         return ingame.concat(compendium);
@@ -100,7 +100,7 @@ export class Traversal {
      */
 
     static getInGameEntitiesDataOfType (type) {
-        return game.items.filter(item => item.type === type).map(entity => entity.data);
+        return game.items.filter(item => item.type === type).map(entity => entity);
     }
 
     static getAllCapacitiesData () {
@@ -122,7 +122,7 @@ export class Traversal {
     }
 
     static findPathDataByKey (key) {
-        return this.getAllPathsData().find(entity => entity.data.key === key);
+        return this.getAllPathsData().find(entity => entity.system.key === key);
     }
 
     static find(id) {

--- a/module/utils/traversal.js
+++ b/module/utils/traversal.js
@@ -151,5 +151,5 @@ export class Traversal {
             else return game.packs.get(source).getDocument(id).then(entity => entity);
         }
     }
-    
+
 }

--- a/module/utils/update-utils.js
+++ b/module/utils/update-utils.js
@@ -8,8 +8,8 @@ export class UpdateUtils {
                 // PATHS
                 Traversal.getEntitiesOfType(["path"]).then(paths => {
                     paths.forEach(path => {
-                        let data = duplicate(path.data);
-                        data.data.capacities = data.data.capacities.map(cid => {
+                        let data = duplicate(path);
+                        data.system.capacities = data.system.capacities.map(cid => {
                             if (typeof cid === "string") {
                                 // not updated
                                 return index[cid];
@@ -24,8 +24,8 @@ export class UpdateUtils {
                 // PROFILES
                 Traversal.getEntitiesOfType(["profile"]).then(profiles => {
                     profiles.forEach(profile => {
-                        let data = duplicate(profile.data);
-                        data.data.paths = data.data.paths.map(pid => {
+                        let data = duplicate(profile);
+                        data.system.paths = data.system.paths.map(pid => {
                             if (typeof pid === "string") {
                                 // not updated
                                 return index[pid];

--- a/system.json
+++ b/system.json
@@ -1,10 +1,13 @@
 {
-  "name": "coc",
+  "id": "coc",
   "title": "Chroniques Oubliées Contemporain",
   "description": "<p>Système Foundry VTT pour <a href='https://www.black-book-editions.fr/catalogue.php?id=477'>Chroniques Oubliées Contemporain</a>.</p><p> *** Rejoignez la communauté Discord FR :<a href='https://discord.gg/pPSDNJk'>https://discord.gg/pPSDNJk</a></p>",
-  "version": "9.269.4",
-  "minimumCoreVersion": "9",
-  "compatibleCoreVersion": "9.269",
+  "version": "10.274.1",
+  "compatibility": {
+    "minimum": 10,
+    "verified": "10.274",
+    "maximum": 10
+  },
   "templateVersion": 2,
   "authors": [
     {

--- a/templates/actors/parts/actor-description.hbs
+++ b/templates/actors/parts/actor-description.hbs
@@ -4,4 +4,4 @@
     </div>
 </div>
 <hr/>
-{{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+{{editor system.description target="system.description" button=true owner=owner editable=editable}}

--- a/templates/actors/parts/capacities/actor-capacities.hbs
+++ b/templates/actors/parts/capacities/actor-capacities.hbs
@@ -22,9 +22,9 @@
                                 <div class="item-image" style="background-image: url('{{capacity.img}}')"></div>
                                 <h4>{{capacity.name}}</h4>
                             </div>
-                            <div class="item-detail">{{#if capacity.data.rank}}{{capacity.data.rank}}{{/if}}</div>
-                            <div class="item-detail">{{#if capacity.data.limited}}L{{/if}}</div>
-                            <div class="item-detail">{{#if capacity.data.spell}}&#10033;{{/if}}</div>
+                            <div class="item-detail">{{#if capacity.system.rank}}{{capacity.system.rank}}{{/if}}</div>
+                            <div class="item-detail">{{#if capacity.system.limited}}L{{/if}}</div>
+                            <div class="item-detail">{{#if capacity.system.spell}}&#10033;{{/if}}</div>
                             {{#if @root.editable}}
                                 <div class="item-controls">
                                     <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
@@ -32,10 +32,10 @@
                                 </div>
                             {{/if}}
                             <div class="item-summary" style="display: none">
-                                {{{capacity.data.description}}}
+                                {{{capacity.system.description}}}
                                 <div class="item-properties">
-                                    {{#if capacity.data.spell}}<span class="tag">{{localize "COC.ui.spell"}}</span>{{/if}}
-                                    {{#if capacity.data.limited}}<span class="tag">{{localize "COC.ui.limited"}}</span>{{/if}}
+                                    {{#if capacity.system.spell}}<span class="tag">{{localize "COC.ui.spell"}}</span>{{/if}}
+                                    {{#if capacity.system.limited}}<span class="tag">{{localize "COC.ui.limited"}}</span>{{/if}}
                                 </div>
                             </div>
                         </li>

--- a/templates/actors/parts/capacities/actor-paths.hbs
+++ b/templates/actors/parts/capacities/actor-paths.hbs
@@ -17,7 +17,7 @@
                         <a class="item-edit ellipsis" style="width: 100%; text-align: left" title="{{path.name}}">{{path.name}}</a>&nbsp;
                         <span class="path-controls item" data-item-id="{{path._id}}" style="padding-right:5px;"><a class="item-control item-delete" title="Delete Item"><i class="fas fa-times"></i></a></span>
                     </div>
-                    {{#each path.data.capacities as |capacity id|}}
+                    {{#each path.system.capacities as |capacity id|}}
                         <div class="gridcell gridcell-sm item capacity left color-default no-wrap" data-item-id="{{capacity._id}}" data-item-type="item" data-pack="capacities" data-path-id="{{path._id}}">
                             {{#if capacity.data.checked}}
                                 <a class="capacity-control capacity-checked" title="{{capacity.name}}"><i class="fas fa-square"></i></a>&nbsp;
@@ -36,10 +36,10 @@
                 <div class="flex1 left">
                     <h3>{{localize "COC.ui.activeCapacities"}}</h3>
                 </div>
-                <div class="flex1 right {{#if (isNegative actor.data.xp.value)}}red{{/if}}">
-                    <span class="field-label">{{localize "COC.ui.CapacityPoints"}} {{actor.data.xp.value}}/{{actor.data.xp.max}}</span>
-                    <input name="data.xp.value" type="hidden" value="{{actor.data.xp.value}}" data-dtype="Number"/>
-                    <input name="data.xp.max" type="hidden" value="{{actor.data.xp.max}}" data-dtype="Number"/>
+                <div class="flex1 right {{#if (isNegative actor.system.xp.value)}}red{{/if}}">
+                    <span class="field-label">{{localize "COC.ui.CapacityPoints"}} {{actor.system.xp.value}}/{{actor.system.xp.max}}</span>
+                    <input name="system.xp.value" type="hidden" value="{{actor.system.xp.value}}" data-dtype="Number"/>
+                    <input name="system.xp.max" type="hidden" value="{{actor.system.xp.max}}" data-dtype="Number"/>
                 </div>
             </div>
         {{/if}}
@@ -83,20 +83,20 @@
 {{!--        </div>--}}
 {{!--        {{#if (equals actor.type "character")}}--}}
 {{!--            <hr/>--}}
-{{!--            {{#if (isNegative actor.data.xp.value)}}--}}
+{{!--            {{#if (isNegative actor.system.xp.value)}}--}}
 {{!--                <div class="row flexrow red">--}}
 {{!--                    <div class="flex1 right">--}}
-{{!--                        <span class="field-label">Points de capacités {{actor.data.xp.value}}/{{actor.data.xp.max}}</span>--}}
-{{!--                        <input name="data.xp.value" type="hidden" value="{{actor.data.xp.value}}" data-dtype="Number"/>--}}
-{{!--                        <input name="data.xp.max" type="hidden" value="{{actor.data.xp.max}}" data-dtype="Number"/>--}}
+{{!--                        <span class="field-label">Points de capacités {{actor.system.xp.value}}/{{actor.system.xp.max}}</span>--}}
+{{!--                        <input name="system.xp.value" type="hidden" value="{{actor.system.xp.value}}" data-dtype="Number"/>--}}
+{{!--                        <input name="system.xp.max" type="hidden" value="{{actor.system.xp.max}}" data-dtype="Number"/>--}}
 {{!--                    </div>--}}
 {{!--                </div>--}}
 {{!--            {{else}}--}}
 {{!--                <div class="row flexrow">--}}
 {{!--                    <div class="flex1 right">--}}
-{{!--                        <span class="field-label">Points de capacités {{actor.data.xp.value}}/{{actor.data.xp.max}}</span>--}}
-{{!--                        <input name="data.xp.value" type="hidden" value="{{actor.data.xp.value}}" data-dtype="Number"/>--}}
-{{!--                        <input name="data.xp.max" type="hidden" value="{{actor.data.xp.max}}" data-dtype="Number"/>--}}
+{{!--                        <span class="field-label">Points de capacités {{actor.system.xp.value}}/{{actor.system.xp.max}}</span>--}}
+{{!--                        <input name="system.xp.value" type="hidden" value="{{actor.system.xp.value}}" data-dtype="Number"/>--}}
+{{!--                        <input name="system.xp.max" type="hidden" value="{{actor.system.xp.max}}" data-dtype="Number"/>--}}
 {{!--                    </div>--}}
 {{!--                </div>--}}
 {{!--            {{/if}}--}}

--- a/templates/actors/parts/capacities/encounter-capacities.hbs
+++ b/templates/actors/parts/capacities/encounter-capacities.hbs
@@ -18,18 +18,18 @@
                         <h4>{{name}}</h4>
                     </div>
                     {{#with capacity}}
-                        <div class="item-detail">{{#if data.rank}}{{data.rank}}{{/if}}</div>
-                        <div class="item-detail">{{#if data.limited}}L{{/if}}</div>
-                        <div class="item-detail">{{#if data.spell}}&#10033;{{/if}}</div>
+                        <div class="item-detail">{{#if system.rank}}{{system.rank}}{{/if}}</div>
+                        <div class="item-detail">{{#if system.limited}}L{{/if}}</div>
+                        <div class="item-detail">{{#if system.spell}}&#10033;{{/if}}</div>
                         <div class="item-controls">
                             <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                             <a class="item-control item-delete" title="Delete Item"><i class="fas fa-trash"></i></a>
                         </div>
                         <div class="item-summary" style="display: none">
-                            {{{data.description}}}
+                            {{{system.description}}}
                             <div class="item-properties">
-                                {{#if data.spell}}<span class="tag">{{localize "COC.ui.spell"}}</span>{{/if}}
-                                {{#if data.limited}}<span class="tag">{{localize "COC.ui.limited"}}</span>{{/if}}
+                                {{#if system.spell}}<span class="tag">{{localize "COC.ui.spell"}}</span>{{/if}}
+                                {{#if system.limited}}<span class="tag">{{localize "COC.ui.limited"}}</span>{{/if}}
                             </div>
                         </div>
                     {{/with}}

--- a/templates/actors/parts/character-description.hbs
+++ b/templates/actors/parts/character-description.hbs
@@ -3,7 +3,7 @@
         <span class="field-label">{{ localize 'COC.details.gender' }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value" name="data.details.gender" type="text" value="{{actor.data.details.gender}}" placeholder="" data-dtype="String"/>
+        <input class="field-value" name="system.details.gender" type="text" value="{{actor.system.details.gender}}" placeholder="" data-dtype="String"/>
     </div>
 </div>
 <div class="flexrow">
@@ -11,7 +11,7 @@
         <span class="field-label">{{ localize "COC.details.age" }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value" name="data.details.age" type="text" value="{{actor.data.details.age}}" placeholder="" data-dtype="String"/>
+        <input class="field-value" name="system.details.age" type="text" value="{{actor.system.details.age}}" placeholder="" data-dtype="String"/>
     </div>
 </div>
 <div class="flexrow">
@@ -19,7 +19,7 @@
         <span class="field-label">{{ localize "COC.details.height" }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value" name="data.details.height" type="text" value="{{actor.data.details.height}}" placeholder="" data-dtype="String"/>
+        <input class="field-value" name="system.details.height" type="text" value="{{actor.system.details.height}}" placeholder="" data-dtype="String"/>
     </div>
 </div>
 <div class="flexrow">
@@ -27,7 +27,7 @@
         <span class="field-label">{{ localize "COC.details.weight" }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value" name="data.details.weight" type="text" value="{{actor.data.details.weight}}" placeholder="" data-dtype="String"/>
+        <input class="field-value" name="system.details.weight" type="text" value="{{actor.system.details.weight}}" placeholder="" data-dtype="String"/>
     </div>
 </div>
 <div class="flexrow">
@@ -35,7 +35,7 @@
         <span class="field-label">{{ localize "COC.details.eyes" }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value" name="data.details.eyes" type="text" value="{{actor.data.details.eyes}}" placeholder="" data-dtype="String"/>
+        <input class="field-value" name="system.details.eyes" type="text" value="{{actor.system.details.eyes}}" placeholder="" data-dtype="String"/>
     </div>
 </div>
 <div class="flexrow">
@@ -43,16 +43,16 @@
         <span class="field-label">{{ localize "COC.details.hair" }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value" name="data.details.hair" type="text" value="{{actor.data.details.hair}}" placeholder="" data-dtype="String"/>
+        <input class="field-value" name="system.details.hair" type="text" value="{{actor.system.details.hair}}" placeholder="" data-dtype="String"/>
     </div>
 </div>
-{{#if actor.data.milieu}}
+{{#if actor.system.milieu}}
 <div class="flexrow">
     <div class="flex1 center bg-default">
         <span class="field-label">{{ localize 'COC.ui.milieu' }}</span>
     </div>
     <div class="flex4 cell">
-        <input class="field-value sans" name="data.milieu" type="text" value="{{actor.data.milieu}}" placeholder="{{ localize 'COC.ui.milieu' }}" data-dtype="String"/>
+        <input class="field-value sans" name="system.milieu" type="text" value="{{actor.system.milieu}}" placeholder="{{ localize 'COC.ui.milieu' }}" data-dtype="String"/>
     </div>
 </div>
 {{/if}}
@@ -63,4 +63,4 @@
     </div>
 </div>
 <hr/>
-{{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+{{editor system.description target="system.description" button=true owner=owner editable=editable}}

--- a/templates/actors/parts/combat/character-combat-item.hbs
+++ b/templates/actors/parts/combat/character-combat-item.hbs
@@ -4,29 +4,29 @@
         <h4>{{name}}</h4>
     </div>
     {{#if (isNotLimited @root)}}
-        {{#if data.def}}<div class="item-detail">{{numberFormat data.def decimals=0 sign=true}}</div>{{else}}<div class="item-detail"></div>{{/if}}
+        {{#if system.def}}<div class="item-detail">{{numberFormat system.def decimals=0 sign=true}}</div>{{else}}<div class="item-detail"></div>{{/if}}
         <div class="item-detail">
-            {{#if data.properties.ranged}}{{data.range}}{{/if}}
+            {{#if system.properties.ranged}}{{system.range}}{{/if}}
         </div>
         <div class="item-detail">
-            {{#if (equals data.slot "hand")}}
-                {{#if data.properties.2H}}
+            {{#if (equals system.slot "hand")}}
+                {{#if system.properties.2H}}
                     <i class="fas fa-hand-paper"></i><i class="fas fa-hand-paper"></i>
                 {{else}}
                     <i class="fas fa-hand-paper"></i>
                 {{/if}}
             {{/if}}
-        </div>        
+        </div>
         <div class="item-detail item-critrange">
-            {{#if data.properties.weapon}}{{data.critrange}}{{/if}}
+            {{#if system.properties.weapon}}{{system.critrange}}{{/if}}
         </div>
-        <div class="item-detail item-mod" data-item-mod="{{data.mod}}">
-            {{#if data.properties.weapon}}{{data.mod}}{{/if}}
+        <div class="item-detail item-mod" data-item-mod="{{system.mod}}">
+            {{#if system.properties.weapon}}{{system.mod}}{{/if}}
         </div>
-        <div class="item-detail item-dmg" data-item-dmg="{{data.dmg}}">{{#if data.properties.weapon}}{{data.dmg}}{{/if}}</div>
+        <div class="item-detail item-dmg" data-item-dmg="{{system.dmg}}">{{#if system.properties.weapon}}{{system.dmg}}{{/if}}</div>
         {{#if @root.editable}}
             <div class="item-controls">
-                {{#if data.properties.weapon}}
+                {{#if system.properties.weapon}}
                     <a class="item-control rollable" data-roll-type="weapon"><i class="fas fa-dice-d20"></i></a>
                     <a class="item-control rollable" data-roll-type="damage"><i class="fas fa-dice"></i></a>
                 {{/if}}

--- a/templates/actors/parts/combat/encounter-combat.hbs
+++ b/templates/actors/parts/combat/encounter-combat.hbs
@@ -2,7 +2,7 @@
     <li class="inventory-header flexrow">
         <h3 class="item-name flexrow">Attaques</h3>
         <div class="item-detail">Portée</div>
-        <div class="item-detail">Critique</div>        
+        <div class="item-detail">Critique</div>
         <div class="item-detail">Mod</div>
         <div class="item-detail">DM</div>
         <div class="item-controls-3">
@@ -19,11 +19,11 @@
                     <div class="item-image encounter-attack-icon" style="background-image: url('{{img}}')"></div>
                     <h4 class="weapon-name">{{name}}</h4>
                 </div>
-                {{#with data.weapon as |weapon|}}
+                {{#with system.weapon as |weapon|}}
                     <div class="item-detail">{{range}}</div>
-                    <div class="item-detail weapon-crit">{{critrange}}</div>                
+                    <div class="item-detail weapon-crit">{{critrange}}</div>
                     <div class="item-detail weapon-mod">{{numberFormat modTotal decimals=0 sign=true}}</div>
-                    <div class="item-detail weapon-dmg">{{dmgTotal}}</div>            
+                    <div class="item-detail weapon-dmg">{{dmgTotal}}</div>
                     <div class="item-controls-3">
                         <a class="item-control item-edit" title="Edit Item"><i class="fas fa-edit"></i></a>
                         <a class="item-control rollable" data-roll-type="encounter-weapon"><i class="fas fa-dice-d20"></i></a>
@@ -32,7 +32,7 @@
                     </div>
                 {{/with}}
                 <div class="item-summary" style="display: none">
-                    {{{data.description}}}
+                    {{{system.description}}}
                 </div>
             </li>
         {{/each}}

--- a/templates/actors/parts/combat/npc-combat-item.hbs
+++ b/templates/actors/parts/combat/npc-combat-item.hbs
@@ -4,19 +4,19 @@
         <h4>{{name}}</h4>
     </div>
     {{#if (isNotLimited @root)}}
-        {{#if data.def}}<div class="item-detail">{{numberFormat data.def decimals=0 sign=true}}</div>{{else}}<div class="item-detail"></div>{{/if}}
+        {{#if system.def}}<div class="item-detail">{{numberFormat system.def decimals=0 sign=true}}</div>{{else}}<div class="item-detail"></div>{{/if}}
         <div class="item-detail">
-            {{#if data.properties.ranged}}{{data.range}}{{/if}}
+            {{#if system.properties.ranged}}{{system.range}}{{/if}}
         </div>
         <div class="item-detail item-critrange">
-            {{#if data.properties.weapon}}{{data.critrange}}{{/if}}
+            {{#if system.properties.weapon}}{{system.critrange}}{{/if}}
         </div>
-        <div class="item-detail item-mod" data-item-mod="{{data.mod}}">
-            {{#if data.properties.weapon}}{{data.mod}}{{/if}}
+        <div class="item-detail item-mod" data-item-mod="{{system.mod}}">
+            {{#if system.properties.weapon}}{{system.mod}}{{/if}}
         </div>
-        <div class="item-detail item-dmg" data-item-dmg="{{data.dmg}}">{{#if data.properties.weapon}}{{data.dmg}}{{/if}}</div>
+        <div class="item-detail item-dmg" data-item-dmg="{{system.dmg}}">{{#if system.properties.weapon}}{{system.dmg}}{{/if}}</div>
         <div class="item-controls">
-            {{#if data.properties.weapon}}
+            {{#if system.properties.weapon}}
                 <a class="item-control rollable" data-roll-type="weapon"><i class="fas fa-dice-d20"></i></a>
                 <a class="item-control rollable" data-roll-type="damage"><i class="fas fa-dice"></i></a>
             {{/if}}

--- a/templates/actors/parts/details/actor-details.hbs
+++ b/templates/actors/parts/details/actor-details.hbs
@@ -17,13 +17,13 @@
                     <span class="field-label">{{ localize 'COC.attributes.level.label' }}</span>
                 </div>
                 <div class="flex2 center cell">
-                    <input class="level" name="data.level.value" type="text" value="{{actor.data.level.value}}" placeholder="Level" data-dtype="Number"/>
+                    <input class="level" name="system.level.value" type="text" value="{{actor.system.level.value}}" placeholder="Level" data-dtype="Number"/>
                 </div>
             </div>
         {{/if}}
         <!-- /LEVEL -->
     </div>
-    <div class="flex1 layout">        
+    <div class="flex1 layout">
         {{#if (isNotLimited @root)}}
             <!-- TRAIT -->
             <div class="flexrow">
@@ -40,7 +40,7 @@
                 </div>
             </div>
             <!-- /TRAIT -->
-            <!-- PROFILE -->        
+            <!-- PROFILE -->
             <div class="flexrow">
                 <div class="flex2 center cell-header">
                     <span class="field-label">{{ localize 'COC.details.profile' }}</span>
@@ -52,7 +52,7 @@
                     <a class="item-control item-delete" title="Delete Item"><i class="fas fa-times"></i></a>
                 </div>
                 {{/with}}
-                </div>       
+                </div>
             </div>
             <!-- /PROFILE -->
         {{/if}}

--- a/templates/actors/parts/details/encounter-details.hbs
+++ b/templates/actors/parts/details/encounter-details.hbs
@@ -17,7 +17,7 @@
                     <span class="field-label">{{ localize 'COC.attributes.nc.abbrev' }}</span>
                 </div>
                 <div class="flex2 center cell">
-                    <input class="level" name="data.nc.value" type="text" value="{{actor.data.nc.value}}" placeholder="{{ localize 'COC.attributes.nc.label' }}" data-dtype="Number"/>
+                    <input class="level" name="system.nc.value" type="text" value="{{actor.system.nc.value}}" placeholder="{{ localize 'COC.attributes.nc.label' }}" data-dtype="Number"/>
                 </div>
             </div>
         {{/if}}
@@ -28,8 +28,8 @@
                 <span class="field-label">{{ localize 'COC.details.size' }}</span>
             </div>
             <div class="flex2 center cell">
-                <select name="data.details.size" data-type="String" style="width:100%">
-                    {{#select data.details.size}}
+                <select name="system.details.size" data-type="String" style="width:100%">
+                    {{#select system.details.size}}
                         <option value="">{{localize "COC.None"}}</option>
                         <option value="tiny">Minuscule</option>
                         <option value="small">Très petite</option>
@@ -52,8 +52,8 @@
                     <span class="field-label">{{ localize 'COC.ui.archetype' }}</span>
                 </div>
                 <div class="flex2 center cell">
-                    <select name="data.archetype" data-type="String" style="width:100%">
-                        {{#select data.archetype}}
+                    <select name="system.archetype" data-type="String" style="width:100%">
+                        {{#select system.archetype}}
                             <option value="">{{localize "COC.None"}}</option>
                             <option value="standard">Standard</option>
                             <option value="rapide">Rapide</option>
@@ -70,8 +70,8 @@
                     <span class="field-label">{{ localize 'COC.ui.category' }}</span>
                 </div>
                 <div class="flex2 center cell">
-                    <select name="data.category" data-type="String" style="width:100%">
-                        {{#select data.category}}
+                    <select name="system.category" data-type="String" style="width:100%">
+                        {{#select system.category}}
                             <option value="">{{localize "COC.None"}}</option>
                             <option value="vivante">Vivante</option>
                             <option value="humanoïde">Humanoïde</option>
@@ -88,8 +88,8 @@
                     <span class="field-label">{{ localize 'COC.ui.boss' }}</span>
                 </div>
                 <div class="flex2 center cell">
-                    <select name="data.boss.rank" data-type="String" style="width:100%">
-                        {{#select data.boss.rank}}
+                    <select name="system.boss.rank" data-type="String" style="width:100%">
+                        {{#select system.boss.rank}}
                             <option value="">{{localize "COC.None"}}</option>
                             <option value="1">Endurci</option>
                             <option value="2">Expert</option>

--- a/templates/actors/parts/inventory/actor-inventory-item.hbs
+++ b/templates/actors/parts/inventory/actor-inventory-item.hbs
@@ -1,22 +1,22 @@
-<li class="item flexrow {{#if (and data.properties.stackable (isNegativeOrNull data.qty))}}out-of-charge{{/if}}" data-item-id="{{_id}}" data-item-type="item" data-item-equipable="{{data.properties.equipable}}" data-item-stackable="{{data.properties.stackable}}"  data-item-consumable="{{data.properties.consumable}}" draggable="true">
+<li class="item flexrow {{#if (and system.properties.stackable (isNegativeOrNull system.qty))}}out-of-charge{{/if}}" data-item-id="{{_id}}" data-item-type="item" data-item-equipable="{{system.properties.equipable}}" data-item-stackable="{{system.properties.stackable}}"  data-item-consumable="{{system.properties.consumable}}" draggable="true">
     <div class="item-name flexrow">
         <div class="item-image" style="background-image: url('{{img}}')"></div>
         <h4>{{name}}</h4>
     </div>
     <div class="item-detail">
-        <a class="item-control inventory-qty {{#if data.properties.stackable}}unlocked{{else}}locked{{/if}}" title="Clic gauche pour ajouter, clic droit pour supprimer">{{data.qty}}</a>
+        <a class="item-control inventory-qty {{#if system.properties.stackable}}unlocked{{else}}locked{{/if}}" title="Clic gauche pour ajouter, clic droit pour supprimer">{{system.qty}}</a>
     </div>
-    <div class="item-detail">{{#if data.price}}{{data.price}}{{else}}N.C.{{/if}}</div>
+    <div class="item-detail">{{#if system.price}}{{system.price}}{{else}}N.C.{{/if}}</div>
     {{#if (or (equals owner.type "character") (equals owner.type "npc"))}}
     <div class="item-detail">
-        {{#if data.properties.equipable}}
-            {{#if data.worn}}
+        {{#if system.properties.equipable}}
+            {{#if system.worn}}
                 <a class="item-control inventory-equip" title="Déséquiper"><i class="fas fa-shield-alt"></i></a>
             {{else}}
                 <a class="item-control inventory-equip" title="Équiper" style="color:lightgray;"><i class="fas fa-shield-alt"></i></a>
             {{/if}}
         {{/if}}
-        {{#if (and data.properties.consumable (isPositive data.qty))}}
+        {{#if (and system.properties.consumable (isPositive system.qty))}}
             <a class="item-control inventory-consume" title="Consommer"><i class="fas fa-drumstick-bite"></i></a>
         {{/if}}
     </div>

--- a/templates/actors/parts/stats/actor-attacks.hbs
+++ b/templates/actors/parts/stats/actor-attacks.hbs
@@ -12,33 +12,33 @@
         <div class="field-label">{{ localize 'COC.ui.mod' }}</div>
     </div>
 </div>
-{{#each data.attacks as |attack id|}}
+{{#each system.attacks as |attack id|}}
 <div class="flexrow no-wrap attacks">
-    <div class="flex2 center cell-header rollable" data-rolling="data.attacks.{{id}}" data-roll-type="skillcheck">
+    <div class="flex2 center cell-header rollable" data-rolling="system.attacks.{{id}}" data-roll-type="skillcheck">
         <span class="field-label ellipsis"><i class="fas fa-dice-d20"></i>&nbsp;{{ localize attack.abbrev }}</span>
-        <input name="data.attacks.{{id}}.abbrev" type="hidden" value="{{attack.abbrev}}" data-dtype="String"/>
-        <input name="data.attacks.{{id}}.label" type="hidden" value="{{attack.label}}" data-dtype="String"/>
-        <input name="data.attacks.{{id}}.key" type="hidden" value="{{attack.key}}" data-dtype="String"/>
+        <input name="system.attacks.{{id}}.abbrev" type="hidden" value="{{attack.abbrev}}" data-dtype="String"/>
+        <input name="system.attacks.{{id}}.label" type="hidden" value="{{attack.label}}" data-dtype="String"/>
+        <input name="system.attacks.{{id}}.key" type="hidden" value="{{attack.key}}" data-dtype="String"/>
     </div>
     <div class="flex1 center cell">
         {{#if (isNull attack.base)}}
-            <input class="field-value" name="data.attacks.{{id}}.base" type="text" value="" placeholder="Base" data-dtype="Number"/>
+            <input class="field-value" name="system.attacks.{{id}}.base" type="text" value="" placeholder="Base" data-dtype="Number"/>
         {{else}}
-            <input class="field-value" name="data.attacks.{{id}}.base" type="text" value="{{numberFormat attack.base decimals=0 sign=true}}" placeholder="Base" data-dtype="Number"/>
+            <input class="field-value" name="system.attacks.{{id}}.base" type="text" value="{{numberFormat attack.base decimals=0 sign=true}}" placeholder="Base" data-dtype="Number"/>
         {{/if}}
     </div>
     <div class="flex1 center cell">
         {{#if (isNull attack.base)}}
-            <input class="field-value" name="data.attacks.{{id}}.bonus" type="text" value="" placeholder="Bonus" data-dtype="Number"/>
+            <input class="field-value" name="system.attacks.{{id}}.bonus" type="text" value="" placeholder="Bonus" data-dtype="Number"/>
         {{else}}
-            <input class="field-value" name="data.attacks.{{id}}.bonus" type="text" value="{{numberFormat attack.bonus decimals=0 sign=true}}" placeholder="Bonus" data-dtype="Number"/>
+            <input class="field-value" name="system.attacks.{{id}}.bonus" type="text" value="{{numberFormat attack.bonus decimals=0 sign=true}}" placeholder="Bonus" data-dtype="Number"/>
         {{/if}}
     </div>
     <div class="flex1 center cell readonly">
         {{#if (isNull attack.base)}}
-            <input class="field-value" name="data.attacks.{{id}}.mod" readonly="true" type="text" value="" placeholder="Mod" data-dtype="Number"/>
+            <input class="field-value" name="system.attacks.{{id}}.mod" readonly="true" type="text" value="" placeholder="Mod" data-dtype="Number"/>
         {{else}}
-            <input class="field-value" name="data.attacks.{{id}}.mod" readonly="true" type="text" value="{{numberFormat attack.mod decimals=0 sign=true}}" placeholder="Mod" data-dtype="Number"/>
+            <input class="field-value" name="system.attacks.{{id}}.mod" readonly="true" type="text" value="{{numberFormat attack.mod decimals=0 sign=true}}" placeholder="Mod" data-dtype="Number"/>
         {{/if}}
     </div>
 </div>
@@ -48,8 +48,8 @@
         <div class="field-label ellipsis">{{ localize "COC.ui.sc" }}</div>
     </div>
     <div class="flex1 cell center">
-        <select class="field-value" name="data.attacks.magic.stat" data-type="String" style="width:100%">
-            {{#select data.attacks.magic.stat}}
+        <select class="field-value" name="system.attacks.magic.stat" data-type="String" style="width:100%">
+            {{#select system.attacks.magic.stat}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="@stats.int.mod">{{localize "COC.stats.int.abbrev"}}</option>
                 <option value="@stats.wis.mod">{{localize "COC.stats.wis.abbrev"}}</option>

--- a/templates/actors/parts/stats/actor-attributes.hbs
+++ b/templates/actors/parts/stats/actor-attributes.hbs
@@ -1,5 +1,5 @@
 <div class="flexrow table-header attributes-header no-wrap">
-    <div class="flex2 center rollable" data-rolling="data.stats" data-roll-type="attributes">
+    <div class="flex2 center rollable" data-rolling="system.stats" data-roll-type="attributes">
         <div class="field-label ellipsis"><i class="fas fa-dice-d6"></i>&nbsp;{{ localize 'COC.stats.abbrev' }}</div>
     </div>
     <div class="flex1 center">
@@ -15,14 +15,14 @@
         <div class="field-label">{{ localize 'COC.ui.mod' }}</div>
     </div>
 </div>
-{{#each data.stats as |stat id|}}
+{{#each system.stats as |stat id|}}
 <div class="flexrow no-wrap attributes">
     <div class="flex2 cell-header">
         <div class="flexrow no-wrap">
             <div class="flex1 center no-wrap" title="Supérieur (2d20)">
-                <input type="checkbox" name="data.stats.{{id}}.superior" {{checked stat.superior}}>
+                <input type="checkbox" name="system.stats.{{id}}.superior" {{checked stat.superior}}>
             </div>
-            <div class="flex8 center rollable no-wrap" data-rolling="data.stats.{{id}}" data-roll-type="skillcheck">
+            <div class="flex8 center rollable no-wrap" data-rolling="system.stats.{{id}}" data-roll-type="skillcheck">
                 <div class="field-label no-wrap" title="{{ localize stat.label }}">
                     <i class="fas fa-dice-d20"></i>&nbsp;{{ localize stat.abbrev }}
                 </div>
@@ -30,16 +30,16 @@
         </div>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" name="data.stats.{{id}}.base" type="text" value="{{stat.base}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.base" type="text" value="{{stat.base}}" data-dtype="Number"/>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" name="data.stats.{{id}}.bonus" type="text" value="{{stat.bonus}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.bonus" type="text" value="{{stat.bonus}}" data-dtype="Number"/>
     </div>
     <div class="flex1 center cell readonly">
-        <input class="field-value" name="data.stats.{{id}}.value" readonly="true" type="text" value="{{stat.value}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.value" readonly="true" type="text" value="{{stat.value}}" data-dtype="Number"/>
     </div>
     <div class="flex1 center cell readonly">
-        <input class="field-value" name="data.stats.{{id}}.mod" readonly="true" type="text" value="{{numberFormat stat.mod decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.mod" readonly="true" type="text" value="{{numberFormat stat.mod decimals=0 sign=true}}" data-dtype="Number"/>
     </div>
 </div>
 {{/each}}

--- a/templates/actors/parts/stats/actor-defence.hbs
+++ b/templates/actors/parts/stats/actor-defence.hbs
@@ -17,13 +17,13 @@
         <span class="field-label"><i class="fas fa-shield-alt"></i>&nbsp;{{ localize 'COC.attributes.def.abbrev' }}</span>
     </div>
     <div class="flex5 center cell">
-        <input class="field-value" name="data.attributes.def.base" type="text" value="{{actor.data.attributes.def.base}}" placeholder="Base" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.def.base" type="text" value="{{actor.system.attributes.def.base}}" placeholder="Base" data-dtype="Number"/>
     </div>
     <div class="flex5 center cell">
-        <input class="field-value" name="data.attributes.def.bonus" type="text" value="{{actor.data.attributes.def.bonus}}" placeholder="Bonus" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.def.bonus" type="text" value="{{actor.system.attributes.def.bonus}}" placeholder="Bonus" data-dtype="Number"/>
     </div>
     <div class="flex6 center cell readonly">
-        <input class="field-value" name="data.attributes.def.value" readonly="true" type="text" value="{{actor.data.attributes.def.value}}" placeholder="Value" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.def.value" readonly="true" type="text" value="{{actor.system.attributes.def.value}}" placeholder="Value" data-dtype="Number"/>
     </div>
 </div>
 {{#if (isEnabled "useDamageResistance")}}
@@ -32,13 +32,13 @@
         <span class="field-label"><i class="fas fa-user-shield"></i>&nbsp;{{ localize 'COC.attributes.dr.abbrev' }}</span>
     </div>
     <div class="flex5 center cell">
-        <input class="field-value" name="data.attributes.dr.base.value" type="text" value="{{actor.data.attributes.dr.base.value}}" placeholder="Base" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.dr.base.value" type="text" value="{{actor.system.attributes.dr.base.value}}" placeholder="Base" data-dtype="Number"/>
     </div>
     <div class="flex5 center cell">
-        <input class="field-value" name="data.attributes.dr.bonus.value" type="text" value="{{actor.data.attributes.dr.bonus.value}}" placeholder="Bonus" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.dr.bonus.value" type="text" value="{{actor.system.attributes.dr.bonus.value}}" placeholder="Bonus" data-dtype="Number"/>
     </div>
     <div class="flex6 center cell readonly">
-        <input class="field-value" name="data.attributes.dr.value" readonly="true" type="text" value="{{actor.data.attributes.dr.value}}" placeholder="Value" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.dr.value" readonly="true" type="text" value="{{actor.system.attributes.dr.value}}" placeholder="Value" data-dtype="Number"/>
     </div>
 </div>
 {{/if}}

--- a/templates/actors/parts/stats/actor-init.hbs
+++ b/templates/actors/parts/stats/actor-init.hbs
@@ -23,22 +23,22 @@
     </div>
     {{#if (equals actor.type "npc")}}
         <div class="flex1 center cell">
-            <input class="field-value" name="data.attributes.init.base" type="text" value="{{actor.data.attributes.init.base}}" placeholder="{{ localize 'COC.attributes.base.abbrev' }}" data-dtype="Number"/>
+            <input class="field-value" name="system.attributes.init.base" type="text" value="{{actor.system.attributes.init.base}}" placeholder="{{ localize 'COC.attributes.base.abbrev' }}" data-dtype="Number"/>
         </div>
     {{else}}
         <div class="flex1 center cell">
-            <input class="field-value" name="data.attributes.init.base" type="text" value="{{actor.data.attributes.init.base}}" placeholder="{{ localize 'COC.attributes.base.abbrev' }}" data-dtype="Number"/>
+            <input class="field-value" name="system.attributes.init.base" type="text" value="{{actor.system.attributes.init.base}}" placeholder="{{ localize 'COC.attributes.base.abbrev' }}" data-dtype="Number"/>
         </div>
     {{/if}}
     <div class="flex1 center cell">
-        <input class="field-value" name="data.attributes.init.bonus" type="text" value="{{actor.data.attributes.init.bonus}}" placeholder="{{ localize 'COC.attributes.bonus.abbrev' }}" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.init.bonus" type="text" value="{{actor.system.attributes.init.bonus}}" placeholder="{{ localize 'COC.attributes.bonus.abbrev' }}" data-dtype="Number"/>
     </div>
     {{#unless (equals actor.type "encounter")}}
     <div class="flex1 center cell readonly">
-        <input class="field-value" name="data.attributes.init.penalty" readonly="true" type="text" value="{{actor.data.attributes.init.penalty}}" placeholder="{{ localize 'COC.attributes.penalty.abbrev' }}" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.init.penalty" readonly="true" type="text" value="{{actor.system.attributes.init.penalty}}" placeholder="{{ localize 'COC.attributes.penalty.abbrev' }}" data-dtype="Number"/>
     </div>
     {{/unless}}
     <div class="flex1 center cell readonly">
-        <input class="field-value" name="data.attributes.init.value" readonly="true" type="text" value="{{actor.data.attributes.init.value}}" placeholder="{{ localize 'COC.attributes.value.abbrev' }}" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.init.value" readonly="true" type="text" value="{{actor.system.attributes.init.value}}" placeholder="{{ localize 'COC.attributes.value.abbrev' }}" data-dtype="Number"/>
     </div>
 </div>

--- a/templates/actors/parts/stats/actor-injuries.hbs
+++ b/templates/actors/parts/stats/actor-injuries.hbs
@@ -11,6 +11,6 @@
         <span class="field-label ellipsis"><i class="fas fa-heart-broken"></i>&nbsp;{{ localize 'COC.attributes.bg.abbrev' }}</span>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.bg.value" type="text" value="{{data.attributes.bg.value}}" placeholder="Value" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.bg.value" type="text" value="{{system.attributes.bg.value}}" placeholder="Value" data-dtype="Number"/>
     </div>
 </div>

--- a/templates/actors/parts/stats/actor-madness.hbs
+++ b/templates/actors/parts/stats/actor-madness.hbs
@@ -12,7 +12,7 @@
         <span class="field-label ellipsis"><i class="fas fa-skull"></i>&nbsp;{{ localize 'COC.attributes.mad.abbrev' }}</span>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.mad.value" type="text" value="{{actor.data.attributes.mad.value}}" placeholder="Value" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.mad.value" type="text" value="{{actor.system.attributes.mad.value}}" placeholder="Value" data-dtype="Number"/>
     </div>
 </div>
 {{/if}}

--- a/templates/actors/parts/stats/actor-recovery.hbs
+++ b/templates/actors/parts/stats/actor-recovery.hbs
@@ -18,19 +18,19 @@
     </div>
     <div class="flexrow no-wrap recovery">
         <div class="flex8 center cell-header">
-            <span class="field-label ellipsis rollable" data-rolling="data.attributes.hp" data-roll-type="recovery" title="dépenser un PR avec PV, SHIFT+click sans PV"><i class="fas fa-heartbeat"></i>&nbsp;</span>{{ localize 'COC.attributes.rp.abbrev' }}
+            <span class="field-label ellipsis rollable" data-rolling="system.attributes.hp" data-roll-type="recovery" title="dépenser un PR avec PV, SHIFT+click sans PV"><i class="fas fa-heartbeat"></i>&nbsp;</span>{{ localize 'COC.attributes.rp.abbrev' }}
         </div>
         <div class="flex3 center cell">
-            <input class="field-value" name="data.attributes.rp.base" type="text" value="{{actor.data.attributes.rp.base}}" placeholder="Base" data-dtype="Number"/>
+            <input class="field-value" name="system.attributes.rp.base" type="text" value="{{actor.system.attributes.rp.base}}" placeholder="Base" data-dtype="Number"/>
         </div>
         <div class="flex3 center cell">
-            <input class="field-value" name="data.attributes.rp.bonus" type="text" value="{{actor.data.attributes.rp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
+            <input class="field-value" name="system.attributes.rp.bonus" type="text" value="{{actor.system.attributes.rp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
         </div>
         <div class="flex3 center cell">
-            <input class="field-value" name="data.attributes.rp.max" type="text" readonly="true" value="{{actor.data.attributes.rp.max}}" placeholder="Max" data-dtype="Number"/>
-        </div>        
+            <input class="field-value" name="system.attributes.rp.max" type="text" readonly="true" value="{{actor.system.attributes.rp.max}}" placeholder="Max" data-dtype="Number"/>
+        </div>
         <div class="flex3 center cell">
-            <input class="field-value" name="data.attributes.rp.value" type="text" value="{{actor.data.attributes.rp.value}}" placeholder="Value" data-dtype="Number"/>
+            <input class="field-value" name="system.attributes.rp.value" type="text" value="{{actor.system.attributes.rp.value}}" placeholder="Value" data-dtype="Number"/>
         </div>
     </div>
     <div class="flexrow"><div class="flex1 half-spacer"></div></div>

--- a/templates/actors/parts/stats/actor-resources.hbs
+++ b/templates/actors/parts/stats/actor-resources.hbs
@@ -13,7 +13,7 @@
     </div>
     <div class="flex3 center">
         <div class="field-label">{{ localize 'COC.ui.current' }}</div>
-    </div>    
+    </div>
 </div>
 {{#if (isEnabled "useFortune")}}
 <div class="flexrow no-wrap resources fortune">
@@ -21,17 +21,17 @@
         <span class="field-label ellipsis"><i class="fas fa-star"></i>&nbsp;{{getFpAbbrev}}</span>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.fp.base" type="text" value="{{actor.data.attributes.fp.base}}" placeholder="Base" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.fp.base" type="text" value="{{actor.system.attributes.fp.base}}" placeholder="Base" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.fp.bonus" type="text" value="{{actor.data.attributes.fp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.fp.bonus" type="text" value="{{actor.system.attributes.fp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.fp.max" type="text" readonly="true" value="{{actor.data.attributes.fp.max}}" placeholder="Max" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.fp.max" type="text" readonly="true" value="{{actor.system.attributes.fp.max}}" placeholder="Max" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.fp.value" type="text" value="{{actor.data.attributes.fp.value}}" placeholder="Value" data-dtype="Number"/>
-    </div>    
+        <input class="field-value" name="system.attributes.fp.value" type="text" value="{{actor.system.attributes.fp.value}}" placeholder="Value" data-dtype="Number"/>
+    </div>
 </div>
 {{/if}}
 {{#if (isEnabled "useMana")}}
@@ -40,16 +40,16 @@
         <span class="field-label ellipsis"><i class="fas fa-hand-sparkles"></i>&nbsp;{{ localize 'COC.attributes.mp.abbrev' }}</span>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.mp.base" type="text" value="{{actor.data.attributes.mp.base}}" placeholder="Base" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.mp.base" type="text" value="{{actor.system.attributes.mp.base}}" placeholder="Base" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.mp.bonus" type="text" value="{{actor.data.attributes.mp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.mp.bonus" type="text" value="{{actor.system.attributes.mp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.mp.max" type="text" readonly="true" value="{{actor.data.attributes.mp.max}}" placeholder="Max" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.mp.max" type="text" readonly="true" value="{{actor.system.attributes.mp.max}}" placeholder="Max" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.mp.value" type="text" value="{{actor.data.attributes.mp.value}}" placeholder="Value" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.mp.value" type="text" value="{{actor.system.attributes.mp.value}}" placeholder="Value" data-dtype="Number"/>
     </div>
 </div>
 {{/if}}

--- a/templates/actors/parts/stats/actor-vitality.hbs
+++ b/templates/actors/parts/stats/actor-vitality.hbs
@@ -1,7 +1,13 @@
 <div class="flexrow table-header vitality-header no-wrap">
-    <div class="flex6 center rollable" data-rolling="data.attributes.hp" data-roll-type="hp">
+    {{#if (equals actor.type "encounter")}}
+    <div class="flex6 center" data-roll-type="hp">
+        <div class="field-label">{{ localize 'COC.attributes.vitality.label' }}</div>
+    </div>
+    {{else}}
+    <div class="flex6 center rollable" data-rolling="system.attributes.hp" data-roll-type="hp">
         <div class="field-label"><i class="fas fa-dice-d6"></i>&nbsp;{{ localize 'COC.attributes.vitality.label' }}</div>
     </div>
+    {{/if}}
     {{#unless (equals actor.type "encounter")}}
     <div class="flex4 center">
         <div class="field-label">{{ localize 'COC.ui.hd' }}</div>
@@ -18,7 +24,7 @@
     </div>
     <div class="flex3 center">
         <div class="field-label">{{ localize 'COC.ui.current' }}</div>
-    </div>    
+    </div>
 </div>
 <div class="flexrow no-wrap vitality">
     <div class="flex6 center cell-header">
@@ -26,8 +32,8 @@
     </div>
     {{#unless (equals actor.type "encounter")}}
     <div class="flex4 center cell readonly">
-        <select class="field-value" name="data.attributes.hd.value" data-type="String" style="width:100%">
-        {{#select actor.data.attributes.hd.value}}
+        <select class="field-value" name="system.attributes.hd.value" data-type="String" style="width:100%">
+        {{#select actor.system.attributes.hd.value}}
             <option value="">{{localize "COC.None"}}</option>
             <option value="1d4">1d4</option>
             <option value="1d6">1d6</option>
@@ -40,15 +46,15 @@
     </div>
     {{/unless}}
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.hp.base" type="text" value="{{actor.data.attributes.hp.base}}" placeholder="Base" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.hp.base" type="text" value="{{actor.system.attributes.hp.base}}" placeholder="Base" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.hp.bonus" type="text" value="{{actor.data.attributes.hp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.hp.bonus" type="text" value="{{actor.system.attributes.hp.bonus}}" placeholder="Bonus" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell readonly">
-        <input class="field-value" name="data.attributes.hp.max" type="text" readonly="true" value="{{actor.data.attributes.hp.max}}" placeholder="Max" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.hp.max" type="text" readonly="true" value="{{actor.system.attributes.hp.max}}" placeholder="Max" data-dtype="Number"/>
     </div>
     <div class="flex3 center cell">
-        <input class="field-value" name="data.attributes.hp.value" type="text" value="{{actor.data.attributes.hp.value}}" placeholder="Value" data-dtype="Number"/>
+        <input class="field-value" name="system.attributes.hp.value" type="text" value="{{actor.system.attributes.hp.value}}" placeholder="Value" data-dtype="Number"/>
     </div>
 </div>

--- a/templates/actors/parts/stats/npc-attributes.hbs
+++ b/templates/actors/parts/stats/npc-attributes.hbs
@@ -12,14 +12,14 @@
         <div class="field-label">{{ localize 'COC.stats.tmpmod.abbrev' }}</div>
     </div>
 </div>
-{{#each data.stats as |stat id|}}
+{{#each system.stats as |stat id|}}
 <div class="row flexrow no-wrap attributes">
     <div class="flex2 cell-header">
         <div class="flexrow no-wrap">
             <div class="flex1 center no-wrap" title="Supérieur (2d20)">
-                <input type="checkbox" name="data.stats.{{id}}.superior" {{checked stat.superior}}>
+                <input type="checkbox" name="system.stats.{{id}}.superior" {{checked stat.superior}}>
             </div>
-            <div class="flex8 center rollable no-wrap" data-rolling="data.stats.{{id}}" data-roll-type="skillcheck">
+            <div class="flex8 center rollable no-wrap" data-rolling="system.stats.{{id}}" data-roll-type="skillcheck">
                 <div class="field-label no-wrap" title="{{ localize stat.label }}">
                     <i class="fas fa-dice-d20"></i>&nbsp;{{ localize stat.abbrev }}
                 </div>
@@ -27,16 +27,16 @@
         </div>
     </div>
     <div class="flex1 center cell readonly">
-        <input class="field-value" name="data.stats.{{id}}.value" readonly="true" type="text" value="{{stat.value}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.value" readonly="true" type="text" value="{{stat.value}}" data-dtype="Number"/>
     </div>
     <div class="flex1 center cell">
-        <input class="field-value" name="data.stats.{{id}}.mod" type="text" value="{{numberFormat stat.mod decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.mod" type="text" value="{{numberFormat stat.mod decimals=0 sign=true}}" data-dtype="Number"/>
     </div>
     <div class="flex1 center cell">
         {{#if (isNull stat.tmpmod)}}
-        <input class="field-value" name="data.stats.{{id}}.tmpmod" type="text" value="" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.tmpmod" type="text" value="" data-dtype="Number"/>
         {{else}}
-        <input class="field-value" name="data.stats.{{id}}.tmpmod" type="text" value="{{numberFormat stat.tmpmod decimals=0 sign=true}}" data-dtype="Number"/>
+        <input class="field-value" name="system.stats.{{id}}.tmpmod" type="text" value="{{numberFormat stat.tmpmod decimals=0 sign=true}}" data-dtype="Number"/>
         {{/if}}
     </div>
 </div>

--- a/templates/effects/effects-item.hbs
+++ b/templates/effects/effects-item.hbs
@@ -1,17 +1,17 @@
 <li class="item effect flexrow" data-item-id="{{id}}" data-item-type="effect" draggable="true">
     <div class="item-name flexrow">
-        <div class="item-image effect-icon" style="background-image: url('{{data.icon}}')"></div>
-        <h4>{{data.label}}</h4>
+        <div class="item-image effect-icon" style="background-image: url('{{icon}}')"></div>
+        <h4>{{label}}</h4>
     </div>
     <div class="item-detail">
-        {{#if data.duration.rounds}}{{data.duration.rounds}} R{{/if}}
-        {{#if data.duration.turns}}{{data.duration.turns}} T{{/if}}
-        {{#if data.duration.seconds}}{{data.duration.seconds}} S{{/if}}
-        {{#if data.isTemporary}}(T)){{/if}}
+        {{#if duration.rounds}}{{duration.rounds}} R{{/if}}
+        {{#if duration.turns}}{{duration.turns}} T{{/if}}
+        {{#if duration.seconds}}{{duration.seconds}} S{{/if}}
+        {{#if isTemporary}}(T){{/if}}
     </div>
     {{#if @root.isEffectsEditable}}
         <div class="item-detail">
-        {{#if data.disabled}}
+        {{#if disabled}}
             <a class="item-control effect-toggle" title="Activer" style="color:lightgray;"><i class="fas fa-toggle-off"></i></a>
         {{else}}
             <a class="item-control effect-toggle" title="Désactiver"><i class="fas fa-toggle-on"></i></a>

--- a/templates/items/item-sheet.hbs
+++ b/templates/items/item-sheet.hbs
@@ -8,8 +8,8 @@
             <div class="item-subtitle">
                 <h4 class="item-type">{{localize (concat "COC.category." item.type)}}</h4>
                 <span class="item-status">
-                    {{#if data.setting}}
-                    {{localize (concat "COC.setting." data.setting)}}
+                    {{#if system.setting}}
+                    {{localize (concat "COC.setting." system.setting)}}
                     {{/if}}
                 </span>
             </div>
@@ -27,7 +27,7 @@
     <section class="sheet-body">
         <div class="tab flexrow active no-wrap" data-group="primary" data-tab="description">
             {{> "systems/coc/templates/items/parts/properties/item-properties.hbs"}}
-            {{editor content=data.description target="data.description" button=true owner=owner editable=editable}}
+            {{editor system.description target="system.description" button=true owner=owner editable=editable}}
         </div>
         {{#if (isNotLimited @root)}}
             <div class="tab details" data-group="primary" data-tab="details">
@@ -51,7 +51,7 @@
                 {{/if}}
             </div>
             <div class="tab" data-group="primary" data-tab="effets">
-                {{> "systems/coc/templates/effects/effects.hbs"}}            
+                {{> "systems/coc/templates/effects/effects.hbs"}}
             </div>
         {{/if}}
     </section>

--- a/templates/items/parts/details/capacity-details.hbs
+++ b/templates/items/parts/details/capacity-details.hbs
@@ -1,15 +1,15 @@
 {{> "systems/coc/templates/items/parts/details/setting-details.hbs"}}
 
 <h3 class="form-header">{{localize "COC.ui.properties"}}</h3>
-<input class="field-value" name="data.key" type="hidden" value="{{data.key}}" placeholder="{{ localize "COC.ui.key" }}" data-dtype="String">
+<input class="field-value" name="system.key" type="hidden" value="{{system.key}}" placeholder="{{ localize "COC.ui.key" }}" data-dtype="String">
 <div class="form-group stacked">
     <label>Propriétés</label>
     <div class="form-fields">
         <label class="checkbox">
-            <input type="checkbox" name="data.limited" {{checked data.limited}}> {{localize "COC.ui.limited"}}
+            <input type="checkbox" name="system.limited" {{checked system.limited}}> {{localize "COC.ui.limited"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.spell" {{checked data.spell}}> {{localize "COC.ui.spell"}}
+            <input type="checkbox" name="system.spell" {{checked system.spell}}> {{localize "COC.ui.spell"}}
         </label>
     </div>
 </div>

--- a/templates/items/parts/details/effects-details.hbs
+++ b/templates/items/parts/details/effects-details.hbs
@@ -2,43 +2,43 @@
 <div class="form-group">
     <label>{{localize "COC.ui.properties"}}</label>
     <div class="form-fields">
-        <label class="checkbox"> <input type="checkbox" name="data.properties.heal" {{checked data.properties.heal}}> {{localize "COC.properties.heal"}}</label>
-        <label class="checkbox"> <input type="checkbox" name="data.properties.buff" {{checked data.properties.buff}}> {{localize "COC.properties.buff"}}</label>
-        <label class="checkbox"> <input type="checkbox" name="data.properties.temporary" {{checked data.properties.temporary}}> {{localize "COC.properties.temporary"}}</label>
-        <label class="checkbox"> <input type="checkbox" name="data.properties.persistent" {{checked data.properties.persistent}}> {{localize "COC.properties.persistent"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.spell" {{checked data.properties.spell}}> {{localize "COC.properties.spell"}}</label>
+        <label class="checkbox"> <input type="checkbox" name="system.properties.heal" {{checked system.properties.heal}}> {{localize "COC.properties.heal"}}</label>
+        <label class="checkbox"> <input type="checkbox" name="system.properties.buff" {{checked system.properties.buff}}> {{localize "COC.properties.buff"}}</label>
+        <label class="checkbox"> <input type="checkbox" name="system.properties.temporary" {{checked system.properties.temporary}}> {{localize "COC.properties.temporary"}}</label>
+        <label class="checkbox"> <input type="checkbox" name="system.properties.persistent" {{checked system.properties.persistent}}> {{localize "COC.properties.persistent"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.spell" {{checked system.properties.spell}}> {{localize "COC.properties.spell"}}</label>
     </div>
 </div>
 
-{{#if data.properties.heal}}
+{{#if system.properties.heal}}
     <div class="form-group">
         <label>{{ localize "COC.ui.heal" }}</label>
         <div class="form-fields">
-            <input type="text" name="data.effects.heal.formula" value="{{data.effects.heal.formula}}" placeholder="{{localize "COC.ui.formula"}}" data-dtype="String"/>
+            <input type="text" name="system.effects.heal.formula" value="{{system.effects.heal.formula}}" placeholder="{{localize "COC.ui.formula"}}" data-dtype="String"/>
         </div>
     </div>
 {{/if}}
 
-{{#if data.properties.buff}}
+{{#if system.properties.buff}}
     <div class="form-group">
         <label>{{ localize "COC.ui.buff" }}</label>
         <div class="form-fields">
-            <input type="text" name="data.effects.buff.formula" value="{{data.effects.buff.formula}}" placeholder="{{localize "COC.ui.formula"}}" data-dtype="String"/>
+            <input type="text" name="system.effects.buff.formula" value="{{system.effects.buff.formula}}" placeholder="{{localize "COC.ui.formula"}}" data-dtype="String"/>
         </div>
     </div>
 {{/if}}
 
-{{#if data.properties.temporary}}
+{{#if system.properties.temporary}}
     <div class="form-group">
         <label>{{ localize "COC.ui.duration" }}</label>
         <div class="form-fields">
-            <input type="number" name="data.properties.duration.formula" value="{{data.properties.duration.formula}}" placeholder="{{localize "COC.ui.formula"}}" data-dtype="Number"/>
+            <input type="number" name="system.properties.duration.formula" value="{{system.properties.duration.formula}}" placeholder="{{localize "COC.ui.formula"}}" data-dtype="Number"/>
         </div>
     </div>
     <div class="form-group">
         <label>{{ localize "COC.ui.units" }}</label>&nbsp;
-        <select name="data.properties.duration.units" data-type="String" style="width:100%">
-        {{#select data.properties.duration.units}}
+        <select name="system.properties.duration.units" data-type="String" style="width:100%">
+        {{#select system.properties.duration.units}}
             <option value="">{{localize "COC.None"}}</option>
             <option value="rounds">{{localize "COC.ui.rounds"}}</option>
             <option value="minutes">{{localize "COC.ui.minutes"}}</option>

--- a/templates/items/parts/details/encounter-weapon-details.hbs
+++ b/templates/items/parts/details/encounter-weapon-details.hbs
@@ -3,21 +3,21 @@
 <div class="form-group">
     <label>{{localize "COC.ui.skill"}} (Mod)</label>
     <div class="form-fields">
-        <input name="data.weapon.mod" type="text" value="{{numberFormat data.weapon.mod decimals=0 sign=true}}" placeholder="{{localize "COC.ui.skillBonus"}}" data-dtype="Number">
+        <input name="system.weapon.mod" type="text" value="{{numberFormat system.weapon.mod decimals=0 sign=true}}" placeholder="{{localize "COC.ui.skillBonus"}}" data-dtype="Number">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{localize "COC.ui.skillBonus"}}</label>
     <div class="form-fields">
-        <input name="data.weapon.skillBonus" type="text" value="{{numberFormat data.weapon.skillBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.skillBonus"}}" data-dtype="Number">
+        <input name="system.weapon.skillBonus" type="text" value="{{numberFormat system.weapon.skillBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.skillBonus"}}" data-dtype="Number">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{localize "COC.ui.critrange"}}</label>
     <div class="form-fields">
-        <input name="data.weapon.critrange" type="text" value="{{data.weapon.critrange}}" placeholder="{{localize "COC.ui.critrange"}}" data-dtype="String">
+        <input name="system.weapon.critrange" type="text" value="{{system.weapon.critrange}}" placeholder="{{localize "COC.ui.critrange"}}" data-dtype="String">
     </div>
 </div>
 
@@ -26,14 +26,14 @@
 <div class="form-group">
     <label>{{localize "COC.ui.dmgBase"}}</label>
     <div class="form-fields">
-        <input name="data.weapon.dmg" type="text" value="{{data.weapon.dmg}}" placeholder="{{localize "COC.ui.dmgBase"}}" data-dtype="String">
+        <input name="system.weapon.dmg" type="text" value="{{system.weapon.dmg}}" placeholder="{{localize "COC.ui.dmgBase"}}" data-dtype="String">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{localize "COC.ui.dmgBonus"}}</label>
     <div class="form-fields">
-        <input name="data.weapon.dmgBonus" type="text" value="{{numberFormat data.weapon.dmgBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.dmgBonus"}}" data-dtype="Number">
+        <input name="system.weapon.dmgBonus" type="text" value="{{numberFormat system.weapon.dmgBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.dmgBonus"}}" data-dtype="Number">
     </div>
 </div>
 
@@ -41,6 +41,6 @@
 <div class="form-group">
     <label>{{localize "COC.ui.range"}}</label>
     <div class="form-fields">
-        <input name="data.weapon.range" type="text" value="{{data.weapon.range}}" placeholder="{{localize "COC.ui.range"}}" data-dtype="String">
+        <input name="system.weapon.range" type="text" value="{{system.weapon.range}}" placeholder="{{localize "COC.ui.range"}}" data-dtype="String">
     </div>
 </div>

--- a/templates/items/parts/details/equipment-details.hbs
+++ b/templates/items/parts/details/equipment-details.hbs
@@ -3,24 +3,24 @@
 <div class="form-group">
     <label>{{localize "COC.ui.properties"}}</label>
     <div class="form-fields">
-        <label class="checkbox"> <input type="checkbox" name="data.properties.equipable" {{checked data.properties.equipable}}> {{localize "COC.ui.equipable"}}</label>
-{{#if (not data.properties.unique)}}
-        <label class="checkbox"> <input type="checkbox" name="data.properties.stackable" {{checked data.properties.stackable}}> {{localize "COC.ui.stackable"}}</label>
+        <label class="checkbox"> <input type="checkbox" name="system.properties.equipable" {{checked system.properties.equipable}}> {{localize "COC.ui.equipable"}}</label>
+{{#if (not system.properties.unique)}}
+        <label class="checkbox"> <input type="checkbox" name="system.properties.stackable" {{checked system.properties.stackable}}> {{localize "COC.ui.stackable"}}</label>
 {{/if}}
-{{#if (not data.properties.stackable)}}
-        <label class="checkbox"> <input type="checkbox" name="data.properties.unique"    {{checked data.properties.unique}}> {{localize "COC.properties.unique"}}</label>
+{{#if (not system.properties.stackable)}}
+        <label class="checkbox"> <input type="checkbox" name="system.properties.unique"    {{checked system.properties.unique}}> {{localize "COC.properties.unique"}}</label>
 {{/if}}
-        <label class="checkbox"><input type="checkbox" name="data.properties.consumable" {{checked data.properties.consumable}}> {{localize "COC.properties.consumable"}}</label>
-        <label class="checkbox"> <input type="checkbox" name="data.properties.tailored"  {{checked data.properties.tailored}}> {{localize "COC.properties.tailored"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.2H" {{checked data.properties.2H}}> {{localize "COC.ui.2H"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.consumable" {{checked system.properties.consumable}}> {{localize "COC.properties.consumable"}}</label>
+        <label class="checkbox"> <input type="checkbox" name="system.properties.tailored"  {{checked system.properties.tailored}}> {{localize "COC.properties.tailored"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.2H" {{checked system.properties.2H}}> {{localize "COC.ui.2H"}}</label>
     </div>
 </div>
-{{#if data.properties.equipable}}
+{{#if system.properties.equipable}}
     <div class="form-group">
         <label>{{localize "COC.ui.slot"}}</label>
         <div class="form-fields">
-            <select name="data.slot" data-type="String" style="width:100%">
-                {{#select data.slot}}
+            <select name="system.slot" data-type="String" style="width:100%">
+                {{#select system.slot}}
                     <option value="">{{localize "COC.None"}}</option>
                     <option value="hand">{{localize "COC.slot.hand"}}</option>
                     <option value="head">{{localize "COC.slot.head"}}</option>
@@ -44,23 +44,23 @@
     </div>
 {{/if}}
 <div class="form-group">
-    <label>{{ localize "COC.ui.price" }}</label>&nbsp; <input type="number" name="data.price" value="{{data.price}}" data-dtype="Number"/>
+    <label>{{ localize "COC.ui.price" }}</label>&nbsp; <input type="number" name="system.price" value="{{system.price}}" data-dtype="Number"/>
 </div>
 <div class="form-group">
-    <label>{{ localize "COC.ui.strmin" }}</label>&nbsp; <input type="number" name="data.strmin" value="{{data.strmin}}" data-dtype="Number"/>
+    <label>{{ localize "COC.ui.strmin" }}</label>&nbsp; <input type="number" name="system.strmin" value="{{system.strmin}}" data-dtype="Number"/>
 </div>
 
-{{#if data.properties.stackable}}
+{{#if system.properties.stackable}}
     <div class="form-group">
         <label>{{ localize "COC.ui.quantity" }}</label>
         <div class="form-fields">
-            <input type="number" name="data.qty" value="{{data.qty}}" placeholder="{{localize "COC.ui.quantity"}}" data-dtype="Number"/>
+            <input type="number" name="system.qty" value="{{system.qty}}" placeholder="{{localize "COC.ui.quantity"}}" data-dtype="Number"/>
         </div>
     </div>
     <div class="form-group">
         <label>{{localize "COC.ui.stacksize"}}</label>
         <div class="form-fields">
-            <input name="data.stacksize" type="text" value="{{data.stacksize}}" placeholder="{{localize "COC.placeholders.stacksize"}}" data-dtype="Number">
+            <input name="system.stacksize" type="text" value="{{system.stacksize}}" placeholder="{{localize "COC.placeholders.stacksize"}}" data-dtype="Number">
         </div>
     </div>
 {{/if}}

--- a/templates/items/parts/details/item-details.hbs
+++ b/templates/items/parts/details/item-details.hbs
@@ -2,8 +2,8 @@
 <div class="form-group">
     <label>Sous-catégorie</label>
     <div class="form-fields">
-        <select name="data.subtype" data-type="String" style="width:100%">
-            {{#select data.subtype}}
+        <select name="system.subtype" data-type="String" style="width:100%">
+            {{#select system.subtype}}
                 {{#each config.itemCategories as | category id |}}
                     <option value="{{id}}">{{localize category}}</option>
                 {{/each}}
@@ -18,39 +18,39 @@
     <label>Traits</label>
     <div class="form-fields">
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.equipment" {{checked data.properties.equipment}}> {{localize "COC.properties.equipment"}}
+            <input type="checkbox" name="system.properties.equipment" {{checked system.properties.equipment}}> {{localize "COC.properties.equipment"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.weapon" {{checked data.properties.weapon}}> {{localize "COC.properties.weapon"}}
+            <input type="checkbox" name="system.properties.weapon" {{checked system.properties.weapon}}> {{localize "COC.properties.weapon"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.protection" {{checked data.properties.protection}}> {{localize "COC.properties.protection"}}
+            <input type="checkbox" name="system.properties.protection" {{checked system.properties.protection}}> {{localize "COC.properties.protection"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.ranged" {{checked data.properties.ranged}}> {{localize "COC.properties.ranged"}}
+            <input type="checkbox" name="system.properties.ranged" {{checked system.properties.ranged}}> {{localize "COC.properties.ranged"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.effects" {{checked data.properties.effects}}> {{localize "COC.properties.effects"}}
+            <input type="checkbox" name="system.properties.effects" {{checked system.properties.effects}}> {{localize "COC.properties.effects"}}
         </label>
     </div>
 </div>
 
-{{#if data.properties.equipment}}
+{{#if system.properties.equipment}}
     {{> "systems/coc/templates/items/parts/details/equipment-details.hbs"}}
 {{/if}}
-{{#if data.properties.weapon}}
+{{#if system.properties.weapon}}
     {{> "systems/coc/templates/items/parts/details/weapon-details.hbs"}}
 {{/if}}
-{{#if data.properties.protection}}
+{{#if system.properties.protection}}
     {{> "systems/coc/templates/items/parts/details/protection-details.hbs"}}
 {{/if}}
-{{#if data.properties.ranged}}
+{{#if system.properties.ranged}}
     {{> "systems/coc/templates/items/parts/details/ranged-details.hbs"}}
 {{/if}}
-{{#if data.properties.effects}}
+{{#if system.properties.effects}}
     {{> "systems/coc/templates/items/parts/details/effects-details.hbs"}}
 {{/if}}
-{{#if data.properties.spell}}
+{{#if system.properties.spell}}
     {{> "systems/coc/templates/items/parts/details/spell-details.hbs"}}
 {{/if}}
 {{#if actor}}

--- a/templates/items/parts/details/path-details.hbs
+++ b/templates/items/parts/details/path-details.hbs
@@ -1,14 +1,14 @@
 {{> "systems/coc/templates/items/parts/details/setting-details.hbs"}}
 
 <h3 class="form-header">{{localize "COC.ui.properties"}}</h3>
-<input class="field-value" name="data.key" type="hidden" value="{{item.data.key}}" placeholder="{{ localize "COC.ui.key" }}" data-dtype="String">
+<input class="field-value" name="system.key" type="hidden" value="{{item.system.key}}" placeholder="{{ localize "COC.ui.key" }}" data-dtype="String">
 
 <div class="form-group stacked">
     <label>Type</label>
     <div class="form-fields">
-        <label class="checkbox"><input type="checkbox" name="data.properties.profile" {{checked data.properties.profile}}> {{localize "COC.properties.profile"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.prestige" {{checked data.properties.prestige}}> {{localize "COC.properties.prestige"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.alternative" {{checked data.properties.alternative}}> {{localize "COC.properties.alternative"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.profile" {{checked system.properties.profile}}> {{localize "COC.properties.profile"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.prestige" {{checked system.properties.prestige}}> {{localize "COC.properties.prestige"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.alternative" {{checked system.properties.alternative}}> {{localize "COC.properties.alternative"}}</label>
     </div>
 </div>
 
@@ -21,7 +21,7 @@
             <a class="item-control item-create coc-compendium-pack" data-pack="coc.capacities" data-open="0" title="Ajouter une capacité"><i class="fas fa-plus"></i>&nbsp; Add</a>
         </div>
     </li>
-    {{#each data.capacities as |capacity id|}}
+    {{#each system.capacities as |capacity id|}}
     <ol class="item-list">
         <li class="item flexrow" data-item-id="{{capacity._id}}" data-item-type="capacity" data-key="{{capacity.data.key}}" draggable="true">
             <div class="item-name flexrow">

--- a/templates/items/parts/details/profile-details.hbs
+++ b/templates/items/parts/details/profile-details.hbs
@@ -1,12 +1,12 @@
 {{> "systems/coc/templates/items/parts/details/setting-details.hbs"}}
 
 <h3 class="form-header">{{localize "COC.ui.properties"}}</h3>
-<input class="field-value" name="data.key" type="hidden" value="{{item.data.key}}" placeholder="{{ localize "COC.ui.key" }}" data-dtype="String">
+<input class="field-value" name="system.key" type="hidden" value="{{item.system.key}}" placeholder="{{ localize "COC.ui.key" }}" data-dtype="String">
 <div class="form-group">
     <label>{{localize "COC.ui.hd"}}</label>
     <div class="form-fields">
-        <select name="data.dv" data-type="String" style="width:100%">
-            {{#select data.dv}}
+        <select name="system.dv" data-type="String" style="width:100%">
+            {{#select system.dv}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="1d4">d4</option>
                 <option value="1d6">d6</option>
@@ -22,8 +22,8 @@
 <div class="form-group">
     <label>Famille de profil</label>
     <div class="form-fields">
-        <select name="data.family" data-type="String" style="width:100%">
-            {{#select data.family}}
+        <select name="system.family" data-type="String" style="width:100%">
+            {{#select system.family}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="action">Action</option>
                 <option value="adventure">Aventure</option>
@@ -36,8 +36,8 @@
 <div class="form-group">
     <label>{{localize "COC.ui.spellcasting"}}</label>
     <div class="form-fields">
-        <select name="data.spellcasting" data-type="String" style="width:100%">
-            {{#select data.spellcasting}}
+        <select name="system.spellcasting" data-type="String" style="width:100%">
+            {{#select system.spellcasting}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="@stats.int.mod">{{localize "COC.stats.int.label"}}</option>
                 <option value="@stats.wis.mod">{{localize "COC.stats.wis.label"}}</option>
@@ -53,31 +53,31 @@
 <div class="form-group">
     <label>{{localize "COC.attacks.melee.label"}}</label>
     <div class="form-fields">
-        <input class="field-value" name="data.bonuses.atc" type="text" value="{{numberFormat data.bonuses.atc decimals=0 sign=true}}" placeholder="{{localize "COC.attacks.melee.label"}}" data-dtype="Number">
+        <input class="field-value" name="system.bonuses.atc" type="text" value="{{numberFormat system.bonuses.atc decimals=0 sign=true}}" placeholder="{{localize "COC.attacks.melee.label"}}" data-dtype="Number">
     </div>
 </div>
 <div class="form-group">
     <label>{{localize "COC.attacks.ranged.label"}}</label>
     <div class="form-fields">
-        <input class="field-value" name="data.bonuses.atd" type="text" value="{{numberFormat data.bonuses.atd decimals=0 sign=true}}" placeholder="{{localize "COC.attacks.ranged.label"}}" data-dtype="Number">
+        <input class="field-value" name="system.bonuses.atd" type="text" value="{{numberFormat system.bonuses.atd decimals=0 sign=true}}" placeholder="{{localize "COC.attacks.ranged.label"}}" data-dtype="Number">
     </div>
 </div>
 <div class="form-group">
     <label>{{localize "COC.attacks.magic.label"}}</label>
     <div class="form-fields">
-        <input class="field-value" name="data.bonuses.atm" type="text" value="{{numberFormat data.bonuses.atm decimals=0 sign=true}}" placeholder="{{localize "COC.attacks.magic.label"}}" data-dtype="Number">
+        <input class="field-value" name="system.bonuses.atm" type="text" value="{{numberFormat system.bonuses.atm decimals=0 sign=true}}" placeholder="{{localize "COC.attacks.magic.label"}}" data-dtype="Number">
     </div>
 </div>
 <div class="form-group">
     <label>{{getFpLabel}}</label>
     <div class="form-fields">
-        <input class="field-value" name="data.bonuses.fp" type="text" value="{{numberFormat data.bonuses.fp decimals=0 sign=true}}" placeholder="{{getFpLabel}}" data-dtype="Number">
+        <input class="field-value" name="system.bonuses.fp" type="text" value="{{numberFormat system.bonuses.fp decimals=0 sign=true}}" placeholder="{{getFpLabel}}" data-dtype="Number">
     </div>
 </div>
 <div class="form-group">
     <label>{{localize "COC.attributes.xp.label"}}</label>
     <div class="form-fields">
-        <input class="field-value" name="data.bonuses.xp" type="text" value="{{numberFormat data.bonuses.xp decimals=0 sign=true}}" placeholder="{{localize "COC.attributes.xp.label"}}" data-dtype="Number">
+        <input class="field-value" name="system.bonuses.xp" type="text" value="{{numberFormat system.bonuses.xp decimals=0 sign=true}}" placeholder="{{localize "COC.attributes.xp.label"}}" data-dtype="Number">
     </div>
 </div>
 
@@ -90,9 +90,9 @@
             <a class="item-control item-create coc-compendium-pack" data-pack="coc.paths" data-open="0" title="Ajouter une voie"><i class="fas fa-plus"></i>&nbsp; Add</a>
         </div>
     </li>
-{{#each data.paths}}
+{{#each system.paths}}
     <ol class="item-list">
-        <li class="item flexrow" data-item-id="{{_id}}" data-item-type="path" data-key="{{data.key}}" draggable="true">
+        <li class="item flexrow" data-item-id="{{_id}}" data-item-type="path" data-key="{{system.key}}" draggable="true">
             <div class="item-name flexrow">
                 <div class="item-image" style="background-image: url('{{img}}')"></div>
                 <h4>{{name}}</h4>

--- a/templates/items/parts/details/protection-details.hbs
+++ b/templates/items/parts/details/protection-details.hbs
@@ -2,10 +2,10 @@
 <div class="form-group">
     <label>{{localize "COC.ui.defBase"}}</label>
     <div class="form-fields">
-        {{#if (isNull data.defBase)}}
-            <input name="data.defBase" type="text" value="" placeholder="{{localize "COC.ui.defBase"}}" data-dtype="Number">
+        {{#if (isNull system.defBase)}}
+            <input name="system.defBase" type="text" value="" placeholder="{{localize "COC.ui.defBase"}}" data-dtype="Number">
         {{else}}
-            <input name="data.defBase" type="text" value="{{numberFormat data.defBase decimals=0 sign=true}}" placeholder="{{localize "COC.ui.defBase"}}" data-dtype="Number">
+            <input name="system.defBase" type="text" value="{{numberFormat system.defBase decimals=0 sign=true}}" placeholder="{{localize "COC.ui.defBase"}}" data-dtype="Number">
         {{/if}}
     </div>
 </div>
@@ -13,10 +13,10 @@
 <div class="form-group">
     <label>{{localize "COC.ui.defBonus"}}</label>
     <div class="form-fields">
-        {{#if (isNull data.defBonus)}}
-            <input name="data.defBonus" type="text" value="" placeholder="{{localize "COC.ui.defBonus"}}" data-dtype="Number">
+        {{#if (isNull system.defBonus)}}
+            <input name="system.defBonus" type="text" value="" placeholder="{{localize "COC.ui.defBonus"}}" data-dtype="Number">
         {{else}}
-            <input name="data.defBonus" type="text" value="{{numberFormat data.defBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.defBonus"}}" data-dtype="Number">
+            <input name="system.defBonus" type="text" value="{{numberFormat system.defBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.defBonus"}}" data-dtype="Number">
         {{/if}}
     </div>
 </div>
@@ -24,15 +24,15 @@
     <label>Propriétés</label>
     <div class="form-fields">
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.dr" {{checked item.data.properties.dr}}> Rédcuction de dommages
+            <input type="checkbox" name="system.properties.dr" {{checked item.system.properties.dr}}> Rédcuction de dommages
         </label>
     </div>
 </div>
-{{#if data.properties.dr}}
+{{#if system.properties.dr}}
 <div class="form-group">
     <label>{{localize "COC.attributes.dr.label"}}</label>
     <div class="form-fields">
-        <input name="data.dr" type="text" value="{{data.dr}}" placeholder="COC.attributes.dr.abbrev" data-dtype="Number">
+        <input name="system.dr" type="text" value="{{system.dr}}" placeholder="COC.attributes.dr.abbrev" data-dtype="Number">
     </div>
 </div>
 {{/if}}

--- a/templates/items/parts/details/ranged-details.hbs
+++ b/templates/items/parts/details/ranged-details.hbs
@@ -2,32 +2,32 @@
 <div class="form-group">
     <label>{{localize "COC.ui.range"}}</label>
     <div class="form-fields">
-        <input name="data.range" type="text" value="{{item.data.range}}" placeholder="Range" data-dtype="Number">
+        <input name="system.range" type="text" value="{{item.system.range}}" placeholder="Range" data-dtype="Number">
     </div>
 </div>
 <div class="form-group">
     <label>Propriétés</label>
     <div class="form-fields">
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.reloadable" {{checked item.data.properties.reloadable}}> {{localize "COC.properties.reloadable"}}
+            <input type="checkbox" name="system.properties.reloadable" {{checked item.system.properties.reloadable}}> {{localize "COC.properties.reloadable"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.salve" {{checked item.data.properties.salve}}> {{localize "COC.properties.salve"}}
+            <input type="checkbox" name="system.properties.salve" {{checked item.system.properties.salve}}> {{localize "COC.properties.salve"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.proneshot" {{checked item.data.properties.proneshot}}> {{localize "COC.properties.proneshot"}}
+            <input type="checkbox" name="system.properties.proneshot" {{checked item.system.properties.proneshot}}> {{localize "COC.properties.proneshot"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.explosive" {{checked item.data.properties.explosive}}> {{localize "COC.properties.explosive"}}
+            <input type="checkbox" name="system.properties.explosive" {{checked item.system.properties.explosive}}> {{localize "COC.properties.explosive"}}
         </label>
     </div>
 </div>
-{{#if data.properties.reloadable}}
+{{#if system.properties.reloadable}}
     <div class="form-group">
         <label>{{localize "COC.ui.reload"}}</label>
         <div class="form-fields">
-            <select name="data.reload" data-type="String" style="width:100%">
-                {{#select data.reload}}
+            <select name="system.reload" data-type="String" style="width:100%">
+                {{#select system.reload}}
                     <option value="">{{localize "COC.ui.noAction"}}</option>
                     <option value="s">{{localize "COC.ui.simpleAction"}}</option>
                     <option value="l">{{localize "COC.ui.limitedAction"}}</option>

--- a/templates/items/parts/details/setting-details.hbs
+++ b/templates/items/parts/details/setting-details.hbs
@@ -1,8 +1,8 @@
 <div class="form-group">
     <label>Setting</label>
     <div class="form-fields">
-        <select name="data.setting" data-type="String" style="width:100%">
-            {{#select data.setting}}
+        <select name="system.setting" data-type="String" style="width:100%">
+            {{#select system.setting}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="base">{{localize "COC.setting.base"}}</option>
                 <option value="epouvante">{{localize "COC.setting.epouvante"}}</option>

--- a/templates/items/parts/details/spell-details.hbs
+++ b/templates/items/parts/details/spell-details.hbs
@@ -3,7 +3,7 @@
     <label>Propriétés</label>
     <div class="form-fields">
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.activable" {{checked item.data.properties.activable}}> {{localize "COC.properties.activable"}}
+            <input type="checkbox" name="system.properties.activable" {{checked item.system.properties.activable}}> {{localize "COC.properties.activable"}}
         </label>
     </div>
 </div>

--- a/templates/items/parts/details/trait-details.hbs
+++ b/templates/items/parts/details/trait-details.hbs
@@ -4,8 +4,8 @@
 <div class="form-group">
     <label>Famille</label>
     <div class="form-fields">
-        <select name="data.family" data-type="String" style="width:100%">
-            {{#select data.family}}
+        <select name="system.family" data-type="String" style="width:100%">
+            {{#select system.family}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="action">Action</option>
                 <option value="reflexion">Réflexion</option>

--- a/templates/items/parts/details/usage-details.hbs
+++ b/templates/items/parts/details/usage-details.hbs
@@ -2,12 +2,12 @@
 <div class="form-group stacked">
     <label>Propriétés</label>
     <div class="form-fields">
-        <label class="checkbox"><input type="checkbox" name="data.properties.proficient" {{checked data.properties.proficient}}> {{localize "COC.properties.proficient"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.predilection" {{checked data.properties.predilection}}> {{localize "COC.properties.predilection"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.finesse" {{checked data.properties.finesse}}> {{localize "COC.properties.finesse"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.sneak" {{checked data.properties.sneak}}> {{localize "COC.properties.sneak"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.powerful" {{checked data.properties.powerful}}> {{localize "COC.properties.powerful"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.critscience" {{checked data.properties.critscience}}> {{localize "COC.properties.critscience"}}</label>
-        <label class="checkbox"><input type="checkbox" name="data.properties.specialization" {{checked data.properties.specialization}}> {{localize "COC.properties.specialization"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.proficient" {{checked system.properties.proficient}}> {{localize "COC.properties.proficient"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.predilection" {{checked system.properties.predilection}}> {{localize "COC.properties.predilection"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.finesse" {{checked system.properties.finesse}}> {{localize "COC.properties.finesse"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.sneak" {{checked system.properties.sneak}}> {{localize "COC.properties.sneak"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.powerful" {{checked system.properties.powerful}}> {{localize "COC.properties.powerful"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.critscience" {{checked system.properties.critscience}}> {{localize "COC.properties.critscience"}}</label>
+        <label class="checkbox"><input type="checkbox" name="system.properties.specialization" {{checked system.properties.specialization}}> {{localize "COC.properties.specialization"}}</label>
     </div>
 </div>

--- a/templates/items/parts/details/weapon-details.hbs
+++ b/templates/items/parts/details/weapon-details.hbs
@@ -2,8 +2,8 @@
 <div class="form-group">
     <label>{{localize "COC.ui.skill"}}</label>
     <div class="form-fields">
-        <select name="data.skill" data-type="String" style="width:100%">
-            {{#select data.skill}}
+        <select name="system.skill" data-type="String" style="width:100%">
+            {{#select system.skill}}
                 <option value="@attacks.melee.mod">{{localize "COC.attacks.melee.label"}}</option>
                 <option value="@attacks.ranged.mod">{{localize "COC.attacks.ranged.label"}}</option>
                 <option value="@attacks.magic.mod">{{localize "COC.attacks.magic.label"}}</option>
@@ -15,22 +15,22 @@
 <div class="form-group">
     <label>{{localize "COC.ui.skillBonus"}}</label>
     <div class="form-fields">
-        <input name="data.skillBonus" type="text" value="{{numberFormat data.skillBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.skillBonus"}}" data-dtype="Number">
+        <input name="system.skillBonus" type="text" value="{{numberFormat system.skillBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.skillBonus"}}" data-dtype="Number">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{localize "COC.ui.dmgBase"}}</label>
     <div class="form-fields">
-        <input name="data.dmgBase" type="text" value="{{data.dmgBase}}" placeholder="{{localize "COC.ui.dmgBase"}}" data-dtype="String">
+        <input name="system.dmgBase" type="text" value="{{system.dmgBase}}" placeholder="{{localize "COC.ui.dmgBase"}}" data-dtype="String">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{localize "COC.ui.dmgStat"}}</label>
     <div class="form-fields">
-        <select name="data.dmgStat" data-type="String" style="width:100%">
-            {{#select data.dmgStat}}
+        <select name="system.dmgStat" data-type="String" style="width:100%">
+            {{#select system.dmgStat}}
                 <option value="">{{localize "COC.None"}}</option>
                 <option value="@stats.str.mod">{{localize "COC.stats.str.label"}}</option>
                 <option value="@stats.dex.mod">{{localize "COC.stats.dex.label"}}</option>
@@ -46,24 +46,24 @@
 <div class="form-group">
     <label>{{localize "COC.ui.dmgBonus"}}</label>
     <div class="form-fields">
-        <input name="data.dmgBonus" type="text" value="{{numberFormat data.dmgBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.dmgBonus"}}" data-dtype="Number">
+        <input name="system.dmgBonus" type="text" value="{{numberFormat system.dmgBonus decimals=0 sign=true}}" placeholder="{{localize "COC.ui.dmgBonus"}}" data-dtype="Number">
     </div>
 </div>
 
 <div class="form-group">
     <label>{{localize "COC.ui.critrange"}}</label>
     <div class="form-fields">
-        <input name="data.critrange" type="text" value="{{data.critrange}}" placeholder="{{localize "COC.ui.critrange"}}" data-dtype="String">
+        <input name="system.critrange" type="text" value="{{system.critrange}}" placeholder="{{localize "COC.ui.critrange"}}" data-dtype="String">
     </div>
 </div>
 <div class="form-group">
     <label>Propriétés</label>
     <div class="form-fields">
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.bashing" {{checked item.data.properties.bashing}}> {{localize "COC.properties.bashing"}}
+            <input type="checkbox" name="system.properties.bashing" {{checked item.system.properties.bashing}}> {{localize "COC.properties.bashing"}}
         </label>
         <label class="checkbox">
-            <input type="checkbox" name="data.properties.13strmin" {{checked item.data.properties.13strmin}}> {{localize "COC.properties.13strmin"}}
+            <input type="checkbox" name="system.properties.13strmin" {{checked item.system.properties.13strmin}}> {{localize "COC.properties.13strmin"}}
         </label>
     </div>
 </div>

--- a/templates/items/parts/properties/capacity-properties.hbs
+++ b/templates/items/parts/properties/capacity-properties.hbs
@@ -1,6 +1,6 @@
 <div class="item-properties">
 <ol class="properties-list">
-    {{#if item.data.limited}}<li>{{localize "COC.ui.limited"}}</li>{{/if}}
-    {{#if item.data.spell}}<li>{{localize "COC.ui.spell"}}</li>{{/if}}
+    {{#if item.system.limited}}<li>{{localize "COC.ui.limited"}}</li>{{/if}}
+    {{#if item.system.spell}}<li>{{localize "COC.ui.spell"}}</li>{{/if}}
 </ol>
 </div>

--- a/templates/items/parts/properties/profile-properties.hbs
+++ b/templates/items/parts/properties/profile-properties.hbs
@@ -1,8 +1,8 @@
 <div class="item-properties">
     <ol class="properties-list">
-        {{#if item.data.dv}}
-            <li>{{ localize "COC.ui.hd" }} : {{item.data.dv}}</li>{{/if}}
-        {{#if item.data.spellcasting}}
-            <li>{{localize "COC.ui.spellcasting"}} : {{localize (concat "COC.stats." (concat item.data.spellcasting ".label"))}}</li>{{/if}}
+        {{#if item.system.dv}}
+            <li>{{ localize "COC.ui.hd" }} : {{item.system.dv}}</li>{{/if}}
+        {{#if item.system.spellcasting}}
+            <li>{{localize "COC.ui.spellcasting"}} : {{localize (concat "COC.stats." (concat item.system.spellcasting ".label"))}}</li>{{/if}}
     </ol>
 </div>


### PR DESCRIPTION
**En bref :**
- Je pense avoir supp tous les warnings et tracké tous les modifs à faire
- J'ai beaucoup testé, mais je ne connais pas bien le système, j'espère que rien ne m'a échappé
- J'ai tenté de faire ça avec un minimum de modifs. Du coup, j'ai gardé quelques nomenclatures (pathData, actorData, etc.). Ca pourra faire l'objet d'un refactor plus tard
- Y'a beaucoup de modifs, genre beaucoup, beaucoup. Je ne m'attendais pas à ça :scream:

----------------------------------

**Réparé :**
- Résistance aux dommages qui ne fonctionnait plus
- Quelques ouvertures/fermetures de packs de compendiums qui ne fonctionnaient pas
- Le jet de vitalité lorsque le niveau est > 1
- Il y avait des erreurs sur les rencontres avec les effets (parce que pas de notion d'équipé/non équipé)

----------------------------------

**Modifié :**
- Pour tout ce qui drag'n drop, le dropData par défaut ne contient plus qu'un `uuid` et un `type`. Du coup, il a fallut que je modifie cette partie
- J'ai retiré la possibilité de faire une macro de rencontre à partir d'une arme. Clairement le code est pas prévu pour ça
- J'ai retiré la possibilité de cliquer sur le bouton vitalité pour les rencontres

----------------------------------

**Bizarre :**
- Je n'ai pas commit, mais je remarque que FVTT met tout seul à jour le compendium d'items. Une idée de pourquoi ? Migrations auto ?

----------------------------------

**Pas bien compris :**
- La fiche permet de modifier les PV avec le bouton "Vitalité". Ca prend bien en compte la formule des règles, mais au lieu d'ajouter à l'existant ca remplace avec un tout nouveau résultat
- Si j'ai bien compris, dans le livre, les points de récupération permettent de récupérer la totalité des PV du personnage. Sur la fiche ca lance une formule que ca ajoute au montant de PV actuel tout en pouvant dépasser le maximum de la fiche
- La résistance aux dommages s'applique à tous les types de dégâts ? Sur la fiche il n'est pas possible de spécifier un type ?
- Il y a une notion de `spell` dans le code qui n'est pas utilisée
- pareil pour `species`

----------------------------------

**Quelques pistes d'améliorations :**
- Dans les fenêtres de jet, la case malus est par défaut positive. Il faut que le joueur rentre un "-X". Je pense qu'on peut directement interpréter la valeur comme étant négative -> Court
- Une option pour retirer le son sur les quelques actions qui en ont (équiper, consommer, etc.) -> Court
- Par défaut, lorsqu'on veut rajouter un objet dans la liste des équipements, le bouton ouvre le compendium. C'est pratique, mais on ne peut pas rajouter un objet qui n'existe pas à la volée. Je pense qu'on devrait avoir une option (shift clic ?) pour simplement créer l'objet vide qu'on peut rapidement modifier -> Court
- Dans la partie "combat" la configuration des objets n'est pas complètement affichée. Du coup, on ne sait pas s'il faut une action limitée ou non, s'il y a un effet ou pas, etc. Je propose d'afficher les tags qu'on trouve dans l'onglet description quand on ouvre la fiche de l'objet directement dans la fiche (on peut faire en sorte de pas tout afficher) -> Court
- Les rencontres utilisent un schéma de données qui est très différent des PJs et PNJs, ce qui fait que les effets ne peuvent pas trop leur être appliqués -> ???