### PR TITLE
fix: apply damage correctly through chat

### DIFF
--- a/module/controllers/hitpoints.js
+++ b/module/controllers/hitpoints.js
@@ -1,3 +1,4 @@
+
 export class Hitpoints {
     static applyToTargets(amount, dr) {
         // on prend les cibles s'il y en a, sinon on prend les tokens actifs.
@@ -21,8 +22,8 @@ export class Hitpoints {
     static onClickChatMessageApplyButton(event, html, data){
         const btn = $(event.currentTarget);
         const btnType = btn.data("apply");
-        const dmg = parseInt(html.find(".dice-total").text());
-        const dr = html.find("#dr").is(":checked");
+        const dmg = parseInt(html.querySelector(".dice-total").textContent);
+        const dr = html.querySelector("#dr").checked;
         switch(btnType){
             case "full"   : Hitpoints.applyToTargets(-dmg, dr); break;
             case "half"   : Hitpoints.applyToTargets(-Math.ceil(dmg/2), dr); break;


### PR DESCRIPTION
Replaced jQuery-style element access with native DOM methods:
- changed `.find(...).text()` to `querySelector(...).textContent`
- changed `.find(...).is(":checked")` to `querySelector(...).checked`

This fixes the bug where damage rolls from chat were not applied properly.